### PR TITLE
fix: snapshot the current value of mutable objects

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -210,10 +210,11 @@ def test_something():
 
 The code is generated in the following way:
 
-1. The code is generated with `repr(value)`
-2. Strings which contain newlines are converted to triple quoted strings.
-3. The code is formatted with black.
-4. The whole file is formatted with black if it was formatted before.
+1. The value is copied with `value = copy.deepcopy(value)`
+2. The code is generated with `repr(value)`
+3. Strings which contain newlines are converted to triple quoted strings.
+4. The code is formatted with black.
+5. The whole file is formatted with black if it was formatted before.
 
 !!! note
     The black formatting of the whole file could not work for the following reasons:

--- a/inline_snapshot/_inline_snapshot.py
+++ b/inline_snapshot/_inline_snapshot.py
@@ -1,5 +1,6 @@
 import ast
 import contextlib
+import copy
 import inspect
 import io
 import token
@@ -151,6 +152,8 @@ class Value(GenericValue):
 
 class FixValue(GenericValue):
     def __eq__(self, other):
+        other = copy.deepcopy(other)
+
         if self._new_value is undefined:
             self._new_value = other
 
@@ -171,6 +174,8 @@ class MinMaxValue(GenericValue):
         raise NotImplemented
 
     def _generic_cmp(self, other):
+        other = copy.deepcopy(other)
+
         if self._new_value is undefined:
             self._new_value = other
         else:
@@ -258,6 +263,8 @@ class MaxValue(MinMaxValue):
 
 class CollectionValue(GenericValue):
     def __contains__(self, item):
+        item = copy.deepcopy(item)
+
         if self._new_value is undefined:
             self._new_value = [item]
         else:


### PR DESCRIPTION
BREAKING CHANGE: values have to be copyable with `copy.deepcopy`

This is a behaviour which is already expected from other libraries.

https://github.com/syrusakbary/snapshottest/issues/99