### PR TITLE
fix: flags fix/trim/create/update are changing the matching snapshots

### DIFF
--- a/inline_snapshot/__init__.py
+++ b/inline_snapshot/__init__.py
@@ -1,3 +1,5 @@
 from ._inline_snapshot import snapshot
 
+__all__ = ["snapshot"]
+
 __version__ = "0.3.0"

--- a/inline_snapshot/_inline_snapshot.py
+++ b/inline_snapshot/_inline_snapshot.py
@@ -532,14 +532,19 @@ class Snapshot:
 
         change.set_tags("inline_snapshot")
 
+        needs_fix = self._value._needs_fix()
+        needs_create = self._value._needs_create()
+        needs_trim = self._value._needs_trim()
+
         if (
             _update_flags.update
+            and not (needs_fix or needs_create or needs_trim)
             or _update_flags.fix
-            and self._value._needs_fix
+            and needs_fix
             or _update_flags.create
-            and self._value._needs_create
+            and needs_create
             or _update_flags.trim
-            and self._value._needs_trim
+            and needs_trim
         ):
             new_value = self._value.get_result(_update_flags)
 

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -250,7 +250,7 @@ updated 1 snapshots
     assert project.source == snapshot(
         """
 def test_a():
-    assert "5" == snapshot("5")
+    assert "5" == snapshot('''5''')
     assert 5 <= snapshot(5)
     assert 5 == snapshot(5)
     """


### PR DESCRIPTION
the handling of the command line flags fix/trim/create/update contained a bug

--inline-snapshot=create changed also snapshots which should only be fixed or trimmed or ...

the flags change now only the snapshots which they should change.