### PR TITLE
Multiline strings

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -213,16 +213,32 @@ The code is generated in the following way:
 1. The value is copied with `value = copy.deepcopy(value)`
 2. The code is generated with `repr(value)`
 3. Strings which contain newlines are converted to triple quoted strings.
+
+    !!! note
+        Missing newlines at start or end are escaped.
+
+        <!-- inline-snapshot: create fix update this -->
+        ``` python
+        def test_something():
+            assert "first line\nsecond line" == snapshot(
+                """\
+        first line
+        second line\
+        """
+            )
+        ```
+
+
 4. The code is formatted with black.
+
+    !!! note
+        The black formatting of the whole file could not work for the following reasons:
+
+        1. black is configured with cli arguments and not in a configuration file.<br>
+           **Solution:** configure black in a [configuration file](https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#configuration-via-a-file)
+        2. inline-snapshot uses a different black version.<br>
+           **Solution:** specify which black version inline-snapshot should use by adding black with a specific version to your dependencies.
+
 5. The whole file is formatted with black if it was formatted before.
-
-!!! note
-    The black formatting of the whole file could not work for the following reasons:
-
-    1. black is configured with cli arguments and not in a configuration file.<br>
-       **Solution:** configure black in a [configuration file](https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#configuration-via-a-file)
-    2. inline-snapshot uses a different black version.<br>
-       **Solution:** specify which black version inline-snapshot should use by adding black with a specific version to your dependencies.
-
 
 --8<-- "README.md:Feedback"

--- a/inline_snapshot/_inline_snapshot.py
+++ b/inline_snapshot/_inline_snapshot.py
@@ -472,6 +472,12 @@ def triple_quote(string):
     backslashes."""
     string, quote_types = _str_literal_helper(string, quote_types=['"""', "'''"])
     quote_type = quote_types[0]
+
+    string = "\\\n" + string
+
+    if not string.endswith("\n"):
+        string = string + "\\\n"
+
     return f"{quote_type}{string}{quote_type}"
 
 

--- a/inline_snapshot/_rewrite_code.py
+++ b/inline_snapshot/_rewrite_code.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import logging
 import pathlib
 from collections import defaultdict
 from dataclasses import dataclass
@@ -146,6 +147,12 @@ class SourceFile:
         code = self.filename.read_text()
 
         is_formatted = code == format_code(code, self.filename)
+
+        if not is_formatted:
+            logging.info(f"file is not formatted with black: {self.filename}")
+            import black
+
+            logging.info(f"black version: {black.__version__}")
 
         line_numbers = LineNumbers(code)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,5 @@
 pytest_plugins = "pytester"
+
+import black
+
+black.files.find_project_root = black.files.find_project_root.__wrapped__  # type: ignore

--- a/tests/test_inline_snapshot.py
+++ b/tests/test_inline_snapshot.py
@@ -678,8 +678,12 @@ def test_string_update(check_update):
     assert check_update(
         'assert "ab\\nc" == snapshot("a"\n "b\\nc")', flags="update"
     ) == snapshot(
-        '''assert "ab\\nc" == snapshot("""ab
-c""")'''
+        '''\
+assert "ab\\nc" == snapshot("""\\
+ab
+c\\
+""")\
+'''
     )
 
     assert (
@@ -692,42 +696,70 @@ c""")'''
 
 def test_string_newline(check_update):
     assert check_update('s = snapshot("a\\nb")', flags="update") == snapshot(
-        '''s = snapshot("""a
-b""")'''
+        '''\
+s = snapshot("""\\
+a
+b\\
+""")\
+'''
     )
 
     assert check_update('s = snapshot("a\\"\\"\\"\\nb")', flags="update") == snapshot(
-        """s = snapshot('''a\"\"\"
-b''')"""
+        """\
+s = snapshot('''\\
+a\"\"\"
+b\\
+''')\
+"""
     )
 
     assert check_update(
         's = snapshot("a\\"\\"\\"\\n\\\'\\\'\\\'b")', flags="update"
     ) == snapshot(
-        '''s = snapshot("""a\\"\\"\\"
-\'\'\'b""")'''
+        '''\
+s = snapshot("""\\
+a\\"\\"\\"
+\'\'\'b\\
+""")\
+'''
     )
 
     assert check_update('s = snapshot(b"a\\nb")') == snapshot('s = snapshot(b"a\\nb")')
 
     assert check_update('s = snapshot("\\n\\\'")', flags="update") == snapshot(
-        '''s = snapshot("""
-'""")'''
+        '''\
+s = snapshot("""\\
+
+'\\
+""")\
+'''
     )
 
     assert check_update('s = snapshot("\\n\\"")', flags="update") == snapshot(
-        """s = snapshot('''
-"''')"""
+        '''\
+s = snapshot("""\\
+
+"\\
+""")\
+'''
     )
 
     assert check_update("s = snapshot(\"'''\\n\\\"\")", flags="update") == snapshot(
-        '''s = snapshot("""\'\'\'
-\\"""")'''
+        '''\
+s = snapshot("""\\
+\'\'\'
+\\"\\
+""")\
+'''
     )
 
     assert check_update('s = snapshot("\\n\b")', flags="update") == snapshot(
-        '''s = snapshot("""
-\\x08""")'''
+        '''\
+s = snapshot("""\\
+
+\\x08\\
+""")\
+'''
     )
 
 
@@ -735,20 +767,30 @@ def test_string_quote_choice(check_update):
     assert check_update(
         "s = snapshot(\" \\'\\'\\' \\'\\'\\' \\\"\\\"\\\"\\n\")", flags="update"
     ) == snapshot(
-        '''s = snapshot(""" \'\'\' \'\'\' \\"\\"\\"
-""")'''
+        '''\
+s = snapshot("""\\
+ \'\'\' \'\'\' \\"\\"\\"
+""")\
+'''
     )
 
     assert check_update(
         's = snapshot(" \\\'\\\'\\\' \\"\\"\\" \\"\\"\\"\\n")', flags="update"
     ) == snapshot(
-        """s = snapshot(''' \\'\\'\\' \"\"\" \"\"\"
-''')"""
+        """\
+s = snapshot('''\\
+ \\'\\'\\' \"\"\" \"\"\"
+''')\
+"""
     )
 
     assert check_update('s = snapshot("\\n\\"")', flags="update") == snapshot(
-        """s = snapshot('''
-"''')"""
+        '''\
+s = snapshot("""\\
+
+"\\
+""")\
+'''
     )
 
 
@@ -766,7 +808,8 @@ def test_format_file(check_update):
     assert check_update(
         'assert ["aaaaaaaaaaaaaaaaa"] * 5 == snapshot()\n', flags="create"
     ) == snapshot(
-        """assert ["aaaaaaaaaaaaaaaaa"] * 5 == snapshot(
+        """\
+assert ["aaaaaaaaaaaaaaaaa"] * 5 == snapshot(
     [
         "aaaaaaaaaaaaaaaaa",
         "aaaaaaaaaaaaaaaaa",
@@ -783,7 +826,8 @@ def test_format_value(check_update):
     assert check_update(
         'assert ["aaaaaaaaaaaaaaaaa"] * 5==  snapshot()\n', flags="create"
     ) == snapshot(
-        """assert ["aaaaaaaaaaaaaaaaa"] * 5==  snapshot([
+        """\
+assert ["aaaaaaaaaaaaaaaaa"] * 5==  snapshot([
     "aaaaaaaaaaaaaaaaa",
     "aaaaaaaaaaaaaaaaa",
     "aaaaaaaaaaaaaaaaa",


### PR DESCRIPTION
multiline strings are formatted in a way which ensures that `"""` are always on one line

``` python
assert "\nsecond line" == snapshot("""\

second line\
""")
```

The first escaped line break `"""\` is always added.
The escaped line break at the end only if the string does not end with a newline.

Thanks goes to @RazerM for the idea in the [snapshottest issue](https://github.com/syrusakbary/snapshottest/issues/164)

