### PR TITLE
fix: fixed edge cases where sub-snapshots had problems with some flags

### DIFF
--- a/inline_snapshot/_rewrite_code.py
+++ b/inline_snapshot/_rewrite_code.py
@@ -207,7 +207,7 @@ class ChangeRecorder:
         for file in self._source_files.values():
             file.rewrite()
 
-    def dump(self):
+    def dump(self):  # pragma: no cover
         for file in self._source_files.values():
             print("file:", file.filename)
             for change in file.replacements:


### PR DESCRIPTION
Sub-snapshots should handle flags correctly.
Fixing values value should not trigger a trim of other values for example.

This merge-request implements an generic test for all combinations of two different snapshots in one sub-snapshot.

