### PR TITLE
fix: show better error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.5.1 (2023-10-20)
+
+### Fix
+
+- show better error messages
+
 ## v0.5.0 (2023-10-15)
 
 ### Feat

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,10 +93,17 @@ You can use `snapshot(x)` like you can use `x` in your assertion with a limited 
 !!! warning
     One snapshot can only be used with one operation.
     The following code will not work:
+    <!-- inline-snapshot: show_error outcome-failed=1 -->
     ``` python
-    s = snapshot(5)
-    assert 5 <= s
-    assert 5 == s  # Error: s is already used with <=
+    def test_something():
+        s = snapshot(5)
+        assert 5 <= s
+        assert 5 == s
+
+
+    # Error:
+    # >       assert 5 == s
+    # E       TypeError: This snapshot cannot be use with `==`, because it was previously used with `x <= snapshot`
     ```
 
 ## Supported usage

--- a/inline_snapshot/__init__.py
+++ b/inline_snapshot/__init__.py
@@ -2,4 +2,4 @@ from ._inline_snapshot import snapshot
 
 __all__ = ["snapshot"]
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ license = "MIT"
 name = "inline-snapshot"
 readme = "README.md"
 repository = "https://github.com/15r10nk/inline-snapshots"
-version = "0.5.0"
+version = "0.5.1"
 
 [tool.poetry.dependencies]
 asttokens = "^2.0.5"

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -507,6 +507,10 @@ def test_docs(project, file, subtests):
                 if flags:
                     new_code = project.source
 
+                if "show_error" in options:
+                    new_code = new_code.split("# Error:")[0]
+                    new_code += "# Error:" + textwrap.indent(result.errorLines(), "# ")
+
                 if (
                     inline_snapshot._inline_snapshot._update_flags.fix
                 ):  # pragma: no cover
@@ -523,6 +527,7 @@ def test_docs(project, file, subtests):
                         assert {
                             f"outcome-{k}={v}"
                             for k, v in result.parseoutcomes().items()
+                            if k in ("failed", "errors", "passed")
                         } == {flag for flag in options if flag.startswith("outcome-")}
                     assert code == new_code
                 else:  # pragma: no cover


### PR DESCRIPTION
show the user better error messages when he mixes snapshot operations.

``` python
def test_something():
    s = snapshot(5)
    assert 5 <= s
    assert 5 == s


# Error:
# >       assert 5 == s
# E       TypeError: This snapshot cannot be use with `==`, because it was previously used with `x <= snapshot`
```