### PR TITLE
Preserve expressions in dicts and lists

### DIFF
--- a/inline_snapshot/_inline_snapshot.py
+++ b/inline_snapshot/_inline_snapshot.py
@@ -133,6 +133,8 @@ class UndecidedValue(GenericValue):
         self._old_value = _old_value
         self._new_value = undefined
         self._old_node = _old_node
+        # Only EqValue sets this
+        self._new_node = None
 
     def _change(self, cls):
         self.__class__ = cls
@@ -646,7 +648,7 @@ class Snapshot:
             or _update_flags.trim
             and needs_trim
         ):
-            if new_node := getattr(self._value, "_new_node", None):
+            if new_node := self._value._new_node:
                 text = self._format(ast.unparse(new_node)).strip()
             else:
                 new_value = self._value.get_result(_update_flags)

--- a/inline_snapshot/_inline_snapshot.py
+++ b/inline_snapshot/_inline_snapshot.py
@@ -174,7 +174,7 @@ class EqValue(GenericValue):
         if self._new_value is undefined:
             self._new_value = other
 
-        if self._needs_fix() and self._old_node is not None:
+        if self._needs_fix() and self._old_node is not None and hasattr(ast, "unparse"):
             frame = inspect.currentframe().f_back.f_back
 
             def value_to_node(value):

--- a/inline_snapshot/_inline_snapshot.py
+++ b/inline_snapshot/_inline_snapshot.py
@@ -522,7 +522,7 @@ def used_externals(tree):
 
 
 class Snapshot:
-    def __init__(self, value, source: Source, node: ast.Call):
+    def __init__(self, value, source, node):
         self._value = UndecidedValue(value)
         self._uses_externals = []
         self._source = source

--- a/inline_snapshot/_inline_snapshot.py
+++ b/inline_snapshot/_inline_snapshot.py
@@ -172,7 +172,7 @@ class EqValue(GenericValue):
         if self._new_value is undefined:
             self._new_value = other
 
-        if self._needs_fix() and self._snapshot._node is not None:
+        if self._needs_fix() and self._snapshot._expr.node is not None:
             frame = inspect.currentframe().f_back.f_back
 
             def value_to_node(value):
@@ -226,7 +226,7 @@ class EqValue(GenericValue):
                 return value_to_node(left)
 
             self._new_node = match(
-                self._new_value, self._old_value, self._snapshot._node.args[0]
+                self._new_value, self._old_value, self._snapshot._expr.node.args[0]
             )
 
         return self._visible_value() == other
@@ -491,11 +491,11 @@ def snapshot(obj=undefined):
         node = expr.node
         if node is None:
             # we can run without knowing of the calling expression but we will not be able to fix code
-            snapshots[key] = Snapshot(obj, None, None)
+            snapshots[key] = Snapshot(obj, None)
         else:
             assert isinstance(node.func, ast.Name)
             assert node.func.id == "snapshot"
-            snapshots[key] = Snapshot(obj, expr.source, expr.node)
+            snapshots[key] = Snapshot(obj, expr)
         found_snapshots.append(snapshots[key])
 
     return snapshots[key]._value
@@ -583,15 +583,14 @@ def used_externals(tree):
 
 
 class Snapshot:
-    def __init__(self, value, source, node):
+    def __init__(self, value, expr):
+        self._expr = expr
         self._value = UndecidedValue(value, self)
         self._uses_externals = []
-        self._source = source
-        self._node = node
 
     @property
     def _filename(self):
-        return self._source.filename
+        return self._expr.source.filename
 
     def _format(self, text):
         return format_code(text, Path(self._filename))
@@ -623,11 +622,11 @@ class Snapshot:
         ]
 
     def _change(self):
-        assert self._node is not None
+        assert self._expr is not None
 
         change = ChangeRecorder.current.new_change()
 
-        tokens = list(self._source.asttokens().get_tokens(self._node))
+        tokens = list(self._expr.source.asttokens().get_tokens(self._expr.node))
         assert tokens[0].string == "snapshot"
         assert tokens[1].string == "("
         assert tokens[-1].string == ")"
@@ -672,12 +671,12 @@ class Snapshot:
             )
 
     def _current_tokens(self):
-        if not self._node.args:
+        if not self._expr.node.args:
             return []
 
         return [
             simple_token(t.type, t.string)
-            for t in self._source.asttokens().get_tokens(self._node.args[0])
+            for t in self._expr.source.asttokens().get_tokens(self._expr.node.args[0])
             if t.type not in ignore_tokens
         ]
 
@@ -711,7 +710,7 @@ class Snapshot:
             yield (token.STRING, repr(current_string))
 
     def _needs_update(self):
-        return self._node is not None and [] != list(
+        return self._expr is not None and [] != list(
             self._normalize_strings(self._current_tokens())
         ) != list(self._normalize_strings(self._value_to_token(self._value._old_value)))
 

--- a/tests/test_inline_snapshot.py
+++ b/tests/test_inline_snapshot.py
@@ -779,3 +779,71 @@ assert Thing() == snapshot()
 """
         )
     )
+
+
+def test_preserve(check_update):
+    assert (
+        check_update(
+            """\
+left = {
+    "a": 1,
+    "b": {
+        "c": 2,
+        "d": [
+            3,
+            4,
+            5,
+        ]
+    },
+    "e": (
+        {
+            "f": 6,
+            "g": 7,
+        },
+    )
+}
+assert left == snapshot({
+    "a": 10,
+    "b": {
+        "c": 2 * 1 + 0,
+        "d": [
+            int(3),
+            40,
+            5,
+        ],
+        "h": 8,
+    },
+    "e": (
+        {
+            "f": 3 + 3,
+        },
+        9,
+    )
+})
+""",
+            reported_flags="update,fix",
+            flags="fix",
+        )
+        == snapshot(
+            """\
+left = {
+    "a": 1,
+    "b": {
+        "c": 2,
+        "d": [
+            3,
+            4,
+            5,
+        ]
+    },
+    "e": (
+        {
+            "f": 6,
+            "g": 7,
+        },
+    )
+}
+assert left == snapshot({"a": 1, "b": {"c": 2 * 1 + 0, "d": [int(3), 4, 5]}, "e": ({"f": 3 + 3, "g": 7},)})
+"""
+        )
+    )

--- a/tests/test_inline_snapshot.py
+++ b/tests/test_inline_snapshot.py
@@ -781,6 +781,7 @@ assert Thing() == snapshot()
     )
 
 
+@pytest.mark.skipif(not hasattr(ast, "unparse"), reason="ast.unparse not available")
 def test_preserve(check_update):
     assert (
         check_update(


### PR DESCRIPTION
Hi!

I mentioned the similar function `devtools.insert_assert` in https://github.com/15r10nk/inline-snapshot/issues/30. We use `insert_assert` a lot at work, but I want to convince the team to switch to `inline-snapshot` because the workflow to update snapshots is nicer.

Anyway, this is an attempt to build a feature that I'd really like that doesn't exist in either library: preserving existing non-literal expressions contained within snapshots where possible. Here's a simple example:

```python
a = 1
left = [a, 2]
assert left == snapshot([a, 3])
# I want fixing the line above to keep the `a`, resulting in:
assert left == snapshot([a, 2])
# instead of:
assert left == snapshot([1, 2])
```

The main motivation is to preserve objects from https://github.com/samuelcolvin/dirty-equals inside snapshots.

I tried implementing some fancy general solution but it didn't go well, so the solution here directly finds matching items inside lists and dicts. This handles items being added, removed, or updated. >90% of our snapshots just have lists, dicts, and primitives, so this should still be very helpful.

This feature might require users to opt in with a new flag or something. I expected it would, but it seems to pass all existing tests as is. Still, it seems likely that there are edge cases where using the new code by default could break things, and you can probably think of those cases much more easily than me. This only needs to work in the simple case of `assert left == snapshot(right)` - one option is to test if that's how `snapshot` is being used.

Let me know what you think of the overall approach and if you have thoughts about the API or possible problems.