### PR TITLE
experimental assert_frame_equal with snapshot support

### DIFF
--- a/inline_snapshot/_inline_snapshot.py
+++ b/inline_snapshot/_inline_snapshot.py
@@ -237,7 +237,7 @@ class EqValue(GenericValue):
         if self._new_value is undefined:
             self._new_value = other
 
-        return self._visible_value() == other
+        return other == self._visible_value()
 
     def _new_code(self):
         return self._value_to_code(self._new_value)
@@ -355,7 +355,7 @@ class EqValue(GenericValue):
             # generic fallback
             new_token = value_to_token(new_value)
 
-            if not old_value == new_value:
+            if not new_value == old_value:
                 flag = "fix"
             elif (
                 self._ast_node is not None

--- a/inline_snapshot/_pandas.py
+++ b/inline_snapshot/_pandas.py
@@ -1,0 +1,37 @@
+from functools import wraps
+from typing import Optional
+
+from pandas import DataFrame
+from pandas.testing import assert_frame_equal as real_assert_frame_equal
+
+
+class Wrapper:
+    def __init__(self, df, cmp):
+        self.df = df
+        self.cmp = cmp
+
+    def __repr__(self):
+        return f"DataFrame({self.df.to_dict()!r})"
+
+    def __eq__(self, other):
+        if not isinstance(other, DataFrame):
+            return NotImplemented
+        return self.cmp(self.df, other)
+
+
+@wraps(real_assert_frame_equal)
+def assert_frame_equal(df, df_snapshot, *args, **kargs):
+    error: Optional[AssertionError] = None
+
+    def cmp(a, b):
+        nonlocal error
+        try:
+            real_assert_frame_equal(a, b, *args, **kargs)
+        except AssertionError as e:
+            error = e
+            return False
+        return True
+
+    if not Wrapper(df, cmp) == df_snapshot:
+        assert error is not None
+        raise error

--- a/inline_snapshot/_pandas.py
+++ b/inline_snapshot/_pandas.py
@@ -2,36 +2,54 @@ from functools import wraps
 from typing import Optional
 
 from pandas import DataFrame
+from pandas import Index
+from pandas import Series
 from pandas.testing import assert_frame_equal as real_assert_frame_equal
+from pandas.testing import assert_index_equal as real_assert_index_equal
+from pandas.testing import assert_series_equal as real_assert_series_equal
 
 
-class Wrapper:
-    def __init__(self, df, cmp):
-        self.df = df
-        self.cmp = cmp
+def make_assert_equals(data_type, assert_equals, repr_function):
 
-    def __repr__(self):
-        return f"DataFrame({self.df.to_dict()!r})"
+    class Wrapper:
+        def __init__(self, df, cmp):
+            self.df = df
+            self.cmp = cmp
 
-    def __eq__(self, other):
-        if not isinstance(other, DataFrame):
-            return NotImplemented
-        return self.cmp(self.df, other)
+        def __repr__(self):
+            return f"{data_type.__name__}({repr(repr_function(self.df))})"
+
+        def __eq__(self, other):
+            if not isinstance(other, data_type):
+                return NotImplemented
+            return self.cmp(self.df, other)
+
+    @wraps(assert_equals)
+    def result(df, df_snapshot, *args, **kargs):
+        error: Optional[AssertionError] = None
+
+        def cmp(a, b):
+            nonlocal error
+            try:
+                assert_equals(a, b, *args, **kargs)
+            except AssertionError as e:
+                error = e
+                return False
+            return True
+
+        if not Wrapper(df, cmp) == df_snapshot:
+            assert error is not None
+            raise error
+
+    return result
 
 
-@wraps(real_assert_frame_equal)
-def assert_frame_equal(df, df_snapshot, *args, **kargs):
-    error: Optional[AssertionError] = None
-
-    def cmp(a, b):
-        nonlocal error
-        try:
-            real_assert_frame_equal(a, b, *args, **kargs)
-        except AssertionError as e:
-            error = e
-            return False
-        return True
-
-    if not Wrapper(df, cmp) == df_snapshot:
-        assert error is not None
-        raise error
+assert_frame_equal = make_assert_equals(
+    DataFrame, real_assert_frame_equal, lambda df: df.to_dict("records")
+)
+assert_series_equal = make_assert_equals(
+    Series, real_assert_series_equal, lambda df: df.to_dict()
+)
+assert_index_equal = make_assert_equals(
+    Index, real_assert_index_equal, lambda df: df.to_list()
+)

--- a/inline_snapshot/_pandas.py
+++ b/inline_snapshot/_pandas.py
@@ -1,15 +1,8 @@
 from functools import wraps
 from typing import Optional
 
-from pandas import DataFrame
-from pandas import Index
-from pandas import Series
-from pandas.testing import assert_frame_equal as real_assert_frame_equal
-from pandas.testing import assert_index_equal as real_assert_index_equal
-from pandas.testing import assert_series_equal as real_assert_series_equal
 
-
-def make_assert_equals(data_type, assert_equals, repr_function):
+def make_assert_equal(data_type, assert_equal, repr_function):
 
     class Wrapper:
         def __init__(self, df, cmp):
@@ -24,14 +17,14 @@ def make_assert_equals(data_type, assert_equals, repr_function):
                 return NotImplemented
             return self.cmp(self.df, other)
 
-    @wraps(assert_equals)
+    @wraps(assert_equal)
     def result(df, df_snapshot, *args, **kargs):
         error: Optional[AssertionError] = None
 
         def cmp(a, b):
             nonlocal error
             try:
-                assert_equals(a, b, *args, **kargs)
+                assert_equal(a, b, *args, **kargs)
             except AssertionError as e:
                 error = e
                 return False
@@ -44,12 +37,21 @@ def make_assert_equals(data_type, assert_equals, repr_function):
     return result
 
 
-assert_frame_equal = make_assert_equals(
-    DataFrame, real_assert_frame_equal, lambda df: df.to_dict("records")
-)
-assert_series_equal = make_assert_equals(
-    Series, real_assert_series_equal, lambda df: df.to_dict()
-)
-assert_index_equal = make_assert_equals(
-    Index, real_assert_index_equal, lambda df: df.to_list()
-)
+try:
+    import pandas
+except:
+    pass
+else:
+    from pandas.testing import assert_frame_equal
+    from pandas.testing import assert_index_equal
+    from pandas.testing import assert_series_equal
+
+    assert_frame_equal = make_assert_equal(
+        pandas.DataFrame, assert_frame_equal, lambda df: df.to_dict("records")
+    )
+    assert_series_equal = make_assert_equal(
+        pandas.Series, assert_series_equal, lambda df: df.to_dict()
+    )
+    assert_index_equal = make_assert_equal(
+        pandas.Index, assert_index_equal, lambda df: df.to_list()
+    )

--- a/poetry.lock
+++ b/poetry.lock
@@ -1004,6 +1004,51 @@ files = [
 setuptools = "*"
 
 [[package]]
+name = "numpy"
+version = "1.26.4"
+description = "Fundamental package for array computing in Python"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "numpy-1.26.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9ff0f4f29c51e2803569d7a51c2304de5554655a60c5d776e35b4a41413830d0"},
+    {file = "numpy-1.26.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2e4ee3380d6de9c9ec04745830fd9e2eccb3e6cf790d39d7b98ffd19b0dd754a"},
+    {file = "numpy-1.26.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d209d8969599b27ad20994c8e41936ee0964e6da07478d6c35016bc386b66ad4"},
+    {file = "numpy-1.26.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ffa75af20b44f8dba823498024771d5ac50620e6915abac414251bd971b4529f"},
+    {file = "numpy-1.26.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:62b8e4b1e28009ef2846b4c7852046736bab361f7aeadeb6a5b89ebec3c7055a"},
+    {file = "numpy-1.26.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a4abb4f9001ad2858e7ac189089c42178fcce737e4169dc61321660f1a96c7d2"},
+    {file = "numpy-1.26.4-cp310-cp310-win32.whl", hash = "sha256:bfe25acf8b437eb2a8b2d49d443800a5f18508cd811fea3181723922a8a82b07"},
+    {file = "numpy-1.26.4-cp310-cp310-win_amd64.whl", hash = "sha256:b97fe8060236edf3662adfc2c633f56a08ae30560c56310562cb4f95500022d5"},
+    {file = "numpy-1.26.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4c66707fabe114439db9068ee468c26bbdf909cac0fb58686a42a24de1760c71"},
+    {file = "numpy-1.26.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:edd8b5fe47dab091176d21bb6de568acdd906d1887a4584a15a9a96a1dca06ef"},
+    {file = "numpy-1.26.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ab55401287bfec946ced39700c053796e7cc0e3acbef09993a9ad2adba6ca6e"},
+    {file = "numpy-1.26.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:666dbfb6ec68962c033a450943ded891bed2d54e6755e35e5835d63f4f6931d5"},
+    {file = "numpy-1.26.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:96ff0b2ad353d8f990b63294c8986f1ec3cb19d749234014f4e7eb0112ceba5a"},
+    {file = "numpy-1.26.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:60dedbb91afcbfdc9bc0b1f3f402804070deed7392c23eb7a7f07fa857868e8a"},
+    {file = "numpy-1.26.4-cp311-cp311-win32.whl", hash = "sha256:1af303d6b2210eb850fcf03064d364652b7120803a0b872f5211f5234b399f20"},
+    {file = "numpy-1.26.4-cp311-cp311-win_amd64.whl", hash = "sha256:cd25bcecc4974d09257ffcd1f098ee778f7834c3ad767fe5db785be9a4aa9cb2"},
+    {file = "numpy-1.26.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b3ce300f3644fb06443ee2222c2201dd3a89ea6040541412b8fa189341847218"},
+    {file = "numpy-1.26.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:03a8c78d01d9781b28a6989f6fa1bb2c4f2d51201cf99d3dd875df6fbd96b23b"},
+    {file = "numpy-1.26.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9fad7dcb1aac3c7f0584a5a8133e3a43eeb2fe127f47e3632d43d677c66c102b"},
+    {file = "numpy-1.26.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:675d61ffbfa78604709862923189bad94014bef562cc35cf61d3a07bba02a7ed"},
+    {file = "numpy-1.26.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab47dbe5cc8210f55aa58e4805fe224dac469cde56b9f731a4c098b91917159a"},
+    {file = "numpy-1.26.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1dda2e7b4ec9dd512f84935c5f126c8bd8b9f2fc001e9f54af255e8c5f16b0e0"},
+    {file = "numpy-1.26.4-cp312-cp312-win32.whl", hash = "sha256:50193e430acfc1346175fcbdaa28ffec49947a06918b7b92130744e81e640110"},
+    {file = "numpy-1.26.4-cp312-cp312-win_amd64.whl", hash = "sha256:08beddf13648eb95f8d867350f6a018a4be2e5ad54c8d8caed89ebca558b2818"},
+    {file = "numpy-1.26.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7349ab0fa0c429c82442a27a9673fc802ffdb7c7775fad780226cb234965e53c"},
+    {file = "numpy-1.26.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:52b8b60467cd7dd1e9ed082188b4e6bb35aa5cdd01777621a1658910745b90be"},
+    {file = "numpy-1.26.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5241e0a80d808d70546c697135da2c613f30e28251ff8307eb72ba696945764"},
+    {file = "numpy-1.26.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f870204a840a60da0b12273ef34f7051e98c3b5961b61b0c2c1be6dfd64fbcd3"},
+    {file = "numpy-1.26.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:679b0076f67ecc0138fd2ede3a8fd196dddc2ad3254069bcb9faf9a79b1cebcd"},
+    {file = "numpy-1.26.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:47711010ad8555514b434df65f7d7b076bb8261df1ca9bb78f53d3b2db02e95c"},
+    {file = "numpy-1.26.4-cp39-cp39-win32.whl", hash = "sha256:a354325ee03388678242a4d7ebcd08b5c727033fcff3b2f536aea978e15ee9e6"},
+    {file = "numpy-1.26.4-cp39-cp39-win_amd64.whl", hash = "sha256:3373d5d70a5fe74a2c1bb6d2cfd9609ecf686d47a2d7b1d37a8f3b6bf6003aea"},
+    {file = "numpy-1.26.4-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:afedb719a9dcfc7eaf2287b839d8198e06dcd4cb5d276a3df279231138e83d30"},
+    {file = "numpy-1.26.4-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95a7476c59002f2f6c590b9b7b998306fba6a5aa646b1e22ddfeaf8f78c3a29c"},
+    {file = "numpy-1.26.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:7e50d0a0cc3189f9cb0aeb3a6a6af18c16f59f004b866cd2be1c14b36134a4a0"},
+    {file = "numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010"},
+]
+
+[[package]]
 name = "packaging"
 version = "24.0"
 description = "Core utilities for Python packages"
@@ -1023,6 +1068,79 @@ python-versions = "*"
 files = [
     {file = "paginate-0.5.6.tar.gz", hash = "sha256:5e6007b6a9398177a7e1648d04fdd9f8c9766a1a945bceac82f1929e8c78af2d"},
 ]
+
+[[package]]
+name = "pandas"
+version = "2.2.2"
+description = "Powerful data structures for data analysis, time series, and statistics"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pandas-2.2.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:90c6fca2acf139569e74e8781709dccb6fe25940488755716d1d354d6bc58bce"},
+    {file = "pandas-2.2.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c7adfc142dac335d8c1e0dcbd37eb8617eac386596eb9e1a1b77791cf2498238"},
+    {file = "pandas-2.2.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4abfe0be0d7221be4f12552995e58723c7422c80a659da13ca382697de830c08"},
+    {file = "pandas-2.2.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8635c16bf3d99040fdf3ca3db669a7250ddf49c55dc4aa8fe0ae0fa8d6dcc1f0"},
+    {file = "pandas-2.2.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:40ae1dffb3967a52203105a077415a86044a2bea011b5f321c6aa64b379a3f51"},
+    {file = "pandas-2.2.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8e5a0b00e1e56a842f922e7fae8ae4077aee4af0acb5ae3622bd4b4c30aedf99"},
+    {file = "pandas-2.2.2-cp310-cp310-win_amd64.whl", hash = "sha256:ddf818e4e6c7c6f4f7c8a12709696d193976b591cc7dc50588d3d1a6b5dc8772"},
+    {file = "pandas-2.2.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:696039430f7a562b74fa45f540aca068ea85fa34c244d0deee539cb6d70aa288"},
+    {file = "pandas-2.2.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8e90497254aacacbc4ea6ae5e7a8cd75629d6ad2b30025a4a8b09aa4faf55151"},
+    {file = "pandas-2.2.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:58b84b91b0b9f4bafac2a0ac55002280c094dfc6402402332c0913a59654ab2b"},
+    {file = "pandas-2.2.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d2123dc9ad6a814bcdea0f099885276b31b24f7edf40f6cdbc0912672e22eee"},
+    {file = "pandas-2.2.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:2925720037f06e89af896c70bca73459d7e6a4be96f9de79e2d440bd499fe0db"},
+    {file = "pandas-2.2.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:0cace394b6ea70c01ca1595f839cf193df35d1575986e484ad35c4aeae7266c1"},
+    {file = "pandas-2.2.2-cp311-cp311-win_amd64.whl", hash = "sha256:873d13d177501a28b2756375d59816c365e42ed8417b41665f346289adc68d24"},
+    {file = "pandas-2.2.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:9dfde2a0ddef507a631dc9dc4af6a9489d5e2e740e226ad426a05cabfbd7c8ef"},
+    {file = "pandas-2.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e9b79011ff7a0f4b1d6da6a61aa1aa604fb312d6647de5bad20013682d1429ce"},
+    {file = "pandas-2.2.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1cb51fe389360f3b5a4d57dbd2848a5f033350336ca3b340d1c53a1fad33bcad"},
+    {file = "pandas-2.2.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eee3a87076c0756de40b05c5e9a6069c035ba43e8dd71c379e68cab2c20f16ad"},
+    {file = "pandas-2.2.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:3e374f59e440d4ab45ca2fffde54b81ac3834cf5ae2cdfa69c90bc03bde04d76"},
+    {file = "pandas-2.2.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:43498c0bdb43d55cb162cdc8c06fac328ccb5d2eabe3cadeb3529ae6f0517c32"},
+    {file = "pandas-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:d187d355ecec3629624fccb01d104da7d7f391db0311145817525281e2804d23"},
+    {file = "pandas-2.2.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:0ca6377b8fca51815f382bd0b697a0814c8bda55115678cbc94c30aacbb6eff2"},
+    {file = "pandas-2.2.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9057e6aa78a584bc93a13f0a9bf7e753a5e9770a30b4d758b8d5f2a62a9433cd"},
+    {file = "pandas-2.2.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:001910ad31abc7bf06f49dcc903755d2f7f3a9186c0c040b827e522e9cef0863"},
+    {file = "pandas-2.2.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66b479b0bd07204e37583c191535505410daa8df638fd8e75ae1b383851fe921"},
+    {file = "pandas-2.2.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:a77e9d1c386196879aa5eb712e77461aaee433e54c68cf253053a73b7e49c33a"},
+    {file = "pandas-2.2.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:92fd6b027924a7e178ac202cfbe25e53368db90d56872d20ffae94b96c7acc57"},
+    {file = "pandas-2.2.2-cp39-cp39-win_amd64.whl", hash = "sha256:640cef9aa381b60e296db324337a554aeeb883ead99dc8f6c18e81a93942f5f4"},
+    {file = "pandas-2.2.2.tar.gz", hash = "sha256:9e79019aba43cb4fda9e4d983f8e88ca0373adbb697ae9c6c43093218de28b54"},
+]
+
+[package.dependencies]
+numpy = [
+    {version = ">=1.22.4", markers = "python_version < \"3.11\""},
+    {version = ">=1.23.2", markers = "python_version == \"3.11\""},
+    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
+]
+python-dateutil = ">=2.8.2"
+pytz = ">=2020.1"
+tzdata = ">=2022.7"
+
+[package.extras]
+all = ["PyQt5 (>=5.15.9)", "SQLAlchemy (>=2.0.0)", "adbc-driver-postgresql (>=0.8.0)", "adbc-driver-sqlite (>=0.8.0)", "beautifulsoup4 (>=4.11.2)", "bottleneck (>=1.3.6)", "dataframe-api-compat (>=0.1.7)", "fastparquet (>=2022.12.0)", "fsspec (>=2022.11.0)", "gcsfs (>=2022.11.0)", "html5lib (>=1.1)", "hypothesis (>=6.46.1)", "jinja2 (>=3.1.2)", "lxml (>=4.9.2)", "matplotlib (>=3.6.3)", "numba (>=0.56.4)", "numexpr (>=2.8.4)", "odfpy (>=1.4.1)", "openpyxl (>=3.1.0)", "pandas-gbq (>=0.19.0)", "psycopg2 (>=2.9.6)", "pyarrow (>=10.0.1)", "pymysql (>=1.0.2)", "pyreadstat (>=1.2.0)", "pytest (>=7.3.2)", "pytest-xdist (>=2.2.0)", "python-calamine (>=0.1.7)", "pyxlsb (>=1.0.10)", "qtpy (>=2.3.0)", "s3fs (>=2022.11.0)", "scipy (>=1.10.0)", "tables (>=3.8.0)", "tabulate (>=0.9.0)", "xarray (>=2022.12.0)", "xlrd (>=2.0.1)", "xlsxwriter (>=3.0.5)", "zstandard (>=0.19.0)"]
+aws = ["s3fs (>=2022.11.0)"]
+clipboard = ["PyQt5 (>=5.15.9)", "qtpy (>=2.3.0)"]
+compression = ["zstandard (>=0.19.0)"]
+computation = ["scipy (>=1.10.0)", "xarray (>=2022.12.0)"]
+consortium-standard = ["dataframe-api-compat (>=0.1.7)"]
+excel = ["odfpy (>=1.4.1)", "openpyxl (>=3.1.0)", "python-calamine (>=0.1.7)", "pyxlsb (>=1.0.10)", "xlrd (>=2.0.1)", "xlsxwriter (>=3.0.5)"]
+feather = ["pyarrow (>=10.0.1)"]
+fss = ["fsspec (>=2022.11.0)"]
+gcp = ["gcsfs (>=2022.11.0)", "pandas-gbq (>=0.19.0)"]
+hdf5 = ["tables (>=3.8.0)"]
+html = ["beautifulsoup4 (>=4.11.2)", "html5lib (>=1.1)", "lxml (>=4.9.2)"]
+mysql = ["SQLAlchemy (>=2.0.0)", "pymysql (>=1.0.2)"]
+output-formatting = ["jinja2 (>=3.1.2)", "tabulate (>=0.9.0)"]
+parquet = ["pyarrow (>=10.0.1)"]
+performance = ["bottleneck (>=1.3.6)", "numba (>=0.56.4)", "numexpr (>=2.8.4)"]
+plot = ["matplotlib (>=3.6.3)"]
+postgresql = ["SQLAlchemy (>=2.0.0)", "adbc-driver-postgresql (>=0.8.0)", "psycopg2 (>=2.9.6)"]
+pyarrow = ["pyarrow (>=10.0.1)"]
+spss = ["pyreadstat (>=1.2.0)"]
+sql-other = ["SQLAlchemy (>=2.0.0)", "adbc-driver-postgresql (>=0.8.0)", "adbc-driver-sqlite (>=0.8.0)"]
+test = ["hypothesis (>=6.46.1)", "pytest (>=7.3.2)", "pytest-xdist (>=2.2.0)"]
+xml = ["lxml (>=4.9.2)"]
 
 [[package]]
 name = "pathspec"
@@ -1715,6 +1833,17 @@ files = [
 ]
 
 [[package]]
+name = "tzdata"
+version = "2024.1"
+description = "Provider of IANA time zone data"
+optional = false
+python-versions = ">=2"
+files = [
+    {file = "tzdata-2024.1-py2.py3-none-any.whl", hash = "sha256:9068bc196136463f5245e51efda838afa15aaeca9903f49050dfa2679db4d252"},
+    {file = "tzdata-2024.1.tar.gz", hash = "sha256:2674120f8d891909751c38abcdfd386ac0a5a1127954fbc332af6b5ceae07efd"},
+]
+
+[[package]]
 name = "urllib3"
 version = "2.2.1"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -1815,4 +1944,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8"
-content-hash = "97b863d8e16d95e25edb7068c864dfb2a329200ba91137bb102d5c02fc322e03"
+content-hash = "03d52810abb34a54337a125d3fd54ede86ca30758f21a0ad9f82ce44cecbc672"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ asttokens = ">=2.0.5"
 black = ">=23.3.0"
 click = ">=8.1.4"
 executing = ">=2.0.0"
+pandas = {version = "^2.2.2", python = ">=3.9"}
 python = ">=3.8"
 rich = ">=13.7.1"
 toml = ">=0.10.2"

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -1,0 +1,42 @@
+import sys
+
+import pytest
+from pandas import DataFrame
+from pandas import Index
+from pandas import Series
+
+from inline_snapshot import snapshot
+from inline_snapshot._pandas import assert_frame_equal
+from inline_snapshot._pandas import assert_index_equal
+from inline_snapshot._pandas import assert_series_equal
+
+nan = float("nan")
+
+
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="no pandas for 3.9")
+def test_df():
+    df = DataFrame({"col0": [1, 2], "col1": [1, 5j], "col3": ["a", "b"]})
+
+    # the second argument can be a snapshot
+    assert_frame_equal(
+        df,
+        snapshot(
+            DataFrame(
+                [
+                    {"col0": 1, "col1": (1 + 0j), "col3": "a"},
+                    {"col0": 2, "col1": 5j, "col3": "b"},
+                ]
+            )
+        ),
+    )
+
+    # and can also be used without a snapshot
+    assert_frame_equal(df, df)
+
+    # for Index
+    index = Index(range(5))
+    assert_index_equal(index, snapshot(Index([0, 1, 2, 3, 4])))
+
+    # for Series
+    index = Series({1: 8, 5: 4})
+    assert_series_equal(index, snapshot(Series({1: 8, 5: 4})))

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -1,16 +1,16 @@
 import sys
 
 import pytest
-from pandas import DataFrame
-from pandas import Index
-from pandas import Series
 
-from inline_snapshot import snapshot
-from inline_snapshot._pandas import assert_frame_equal
-from inline_snapshot._pandas import assert_index_equal
-from inline_snapshot._pandas import assert_series_equal
+if sys.version_info >= (3, 9):
+    from pandas import DataFrame
+    from pandas import Index
+    from pandas import Series
 
-nan = float("nan")
+    from inline_snapshot import snapshot
+    from inline_snapshot._pandas import assert_frame_equal
+    from inline_snapshot._pandas import assert_index_equal
+    from inline_snapshot._pandas import assert_series_equal
 
 
 @pytest.mark.skipif(sys.version_info < (3, 9), reason="no pandas for 3.9")


### PR DESCRIPTION
This branch contains a `assert_frame_equal` which can be used with a snapshot argument.
It uses internal `pandas.testing.assert_frame_equal` and provides the same arguments.

> [!IMPORTANT]
> this branch is **experimental** and will **never be merged into this project**.
> I keep it here to simplify the development and will provide a separate package which adds pandas support for inline-snapshot when this experiment works out.

You can migrate your code by changing the import
```python
from pandas.testing import assert_frame_equal
from inline_snapshot._pandas import assert_frame_equal
```

You can use it like this:
```python
from inline_snapshot._pandas import assert_frame_equal

from inline_snapshot import snapshot
from pandas import DataFrame

def test_df():
   df = DataFrame({"col0": [1, 2]})

   # the second argument can be a snapshot,
   assert_frame_equal(df, snapshot())

   # and the generated code looks like this.
   assert_frame_equal(df, snapshot(DataFrame({"col0": {0: 1, 1: 2}})))

   # it can also be used without a snapshot
   assert_frame_equal(df, df)

```








