### PR TITLE
docs: use correct urls in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">
   <a href="https://15r10nk.github.io/inline-snapshot/">
-    <img src="https://raw.githubusercontent.com/15r10nk/inline-snapshot/main/docs/assets/logo.svg" width="500" alt="inline-snapshot">
+    <img src="docs/assets/logo.svg" width="500" alt="inline-snapshot">
   </a>
 </p>
 

--- a/docs/plugins/pyproject.toml
+++ b/docs/plugins/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+build-backend = "hatchling.build"
+requires = ["hatchling"]
+
+[project]
+authors = [
+  {name = "Frank Hoffmann", email = "15r10nk@polarbit.de"}
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Implementation :: PyPy"
+]
+dependencies = [
+  "mkdocs"
+]
+license = "MIT"
+name = "replace-url"
+requires-python = ">=3.8"
+version = "0.3.0"
+
+[project.entry-points."mkdocs.plugins"]
+replace-url = "replace_url:ReplaceUrlPlugin"

--- a/docs/plugins/replace_url.py
+++ b/docs/plugins/replace_url.py
@@ -1,0 +1,6 @@
+import mkdocs
+
+
+class ReplaceUrlPlugin(mkdocs.plugins.BasePlugin):
+    def on_page_content(self, html, page, config, files):
+        return html.replace("docs/assets", "assets")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ plugins:
           heading_level: 3
 - social
 - search
+- replace-url
 
 extra:
   social:

--- a/noxfile.py
+++ b/noxfile.py
@@ -67,11 +67,21 @@ def test(session):
 
 @session(python="python3.10")
 def docs(session):
-    session.install("mkdocs", "mkdocs-material[imaging]", "mkdocstrings[python]")
+    session.install(
+        "mkdocs",
+        "mkdocs-material[imaging]",
+        "mkdocstrings[python]",
+        "docs/plugins",
+    )
     session.run("mkdocs", "build", *session.posargs)
 
 
 @session(python="python3.10")
 def docs_serve(session):
-    session.install("mkdocs", "mkdocs-material[imaging]", "mkdocstrings[python]")
+    session.install(
+        "mkdocs",
+        "mkdocs-material[imaging]",
+        "mkdocstrings[python]",
+        "docs/plugins",
+    )
     session.run("mkdocs", "serve", *session.posargs)


### PR DESCRIPTION
wrote a plugin which let me use relative urls for assets in the README.md and in mkdocs (which includes the readme as snippet)