### PR TITLE
feat: strings with one line-break at the end stay single-quoted strings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
       with:
         name: coverage
         path: .coverage.*
+        include-hidden-files: true
 
   combine_coverage:
     name: combine coverage and check for 100%

--- a/src/inline_snapshot/_utils.py
+++ b/src/inline_snapshot/_utils.py
@@ -126,7 +126,9 @@ def value_to_token(value):
         """Convert strings with newlines in triple quoted strings."""
         if tok.type == token.STRING:
             s = ast.literal_eval(tok.string)
-            if isinstance(s, str) and "\n" in s:
+            if isinstance(s, str) and (
+                ("\n" in s and s[-1] != "\n") or s.count("\n") > 1
+            ):
                 # unparse creates a triple quoted string here,
                 # because it thinks that the string should be a docstring
                 tripple_quoted_string = triple_quote(s)

--- a/tests/test_inline_snapshot.py
+++ b/tests/test_inline_snapshot.py
@@ -686,21 +686,24 @@ s = snapshot("""\\
 
 def test_string_quote_choice(check_update):
     assert check_update(
-        "s = snapshot(\" \\'\\'\\' \\'\\'\\' \\\"\\\"\\\"\\n\")", flags="update"
+        "s = snapshot(\" \\'\\'\\' \\'\\'\\' \\\"\\\"\\\"\\nother_line\")",
+        flags="update",
     ) == snapshot(
         '''\
 s = snapshot("""\\
  \'\'\' \'\'\' \\"\\"\\"
+other_line\\
 """)\
 '''
     )
 
     assert check_update(
-        's = snapshot(" \\\'\\\'\\\' \\"\\"\\" \\"\\"\\"\\n")', flags="update"
+        's = snapshot(" \\\'\\\'\\\' \\"\\"\\" \\"\\"\\"\\nother_line")', flags="update"
     ) == snapshot(
         """\
 s = snapshot('''\\
  \\'\\'\\' \"\"\" \"\"\"
+other_line\\
 ''')\
 """
     )
@@ -712,6 +715,49 @@ s = snapshot("""\\
 "\\
 """)\
 '''
+    )
+
+    assert check_update(
+        "s=snapshot('\\n')", flags="update", reported_flags=""
+    ) == snapshot("s=snapshot('\\n')")
+    assert check_update(
+        "s=snapshot('abc\\n')", flags="update", reported_flags=""
+    ) == snapshot("s=snapshot('abc\\n')")
+    assert check_update("s=snapshot('abc\\nabc')", flags="update") == snapshot(
+        '''\
+s=snapshot("""\\
+abc
+abc\\
+""")\
+'''
+    )
+    assert check_update("s=snapshot('\\nabc')", flags="update") == snapshot(
+        '''\
+s=snapshot("""\\
+
+abc\\
+""")\
+'''
+    )
+    assert check_update("s=snapshot('a\\na\\n')", flags="update") == snapshot(
+        '''\
+s=snapshot("""\\
+a
+a
+""")\
+'''
+    )
+
+    assert (
+        check_update(
+            '''\
+s=snapshot("""\\
+a
+""")\
+''',
+            flags="update",
+        )
+        == snapshot('s=snapshot("a\\n")')
     )
 
 


### PR DESCRIPTION
inline-snapshot generates now:
``` python
s = snapshot('abc\\n')
```
instead of:
``` python
s = snapshot('''\
abc
''')
```

and uses multiline strings only for strings with more than one line.