### PR TITLE
Use tomllib instead of PyPI toml on Python 3.11 and later

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,8 @@ dependencies = [
   "click>=8.1.4",
   "executing>=2.1.0",
   "rich>=13.7.1",
-  "toml>=0.10.2",
-  "types-toml>=0.10.8.7",
+  "toml>=0.10.2; python_version < '3.11'",
+  "types-toml>=0.10.8.7; python_version < '3.11'",
   "typing-extensions"
 ]
 description = "golden master/snapshot/approval testing library which puts the values right into your source code"

--- a/src/inline_snapshot/_config.py
+++ b/src/inline_snapshot/_config.py
@@ -1,10 +1,14 @@
 import os
+import sys
 from dataclasses import dataclass
 from dataclasses import field
 from pathlib import Path
 from typing import List
 
-import toml
+if sys.version_info >= (3, 11):
+    from tomllib import loads
+else:
+    from toml import loads
 
 
 @dataclass
@@ -20,7 +24,7 @@ def read_config(path: Path) -> Config:
     result = Config()
     if path.exists():
 
-        data = toml.loads(path.read_text("utf-8"))
+        data = loads(path.read_text("utf-8"))
 
         try:
             config = data["tool"]["inline-snapshot"]


### PR DESCRIPTION
On Python 3.11 and later, it’s not necessary to carry a dependency on the PyPI [`toml` package](https://pypi.org/project/toml/) since [`tomllib`](https://docs.python.org/3/library/tomllib.html) provides equivalent functionality in the standard library.

Furthermore, the `toml` package was last updated in 2020, and in Fedora Linux, the [`python-toml` package is deprecated](https://fedoraproject.org/wiki/Changes/DeprecatePythonToml), meaning new dependencies on it are prohibited.

I tested this with `hatch test --all` and did not observe any regressions.