### PR TITLE
fix: sort set values

### DIFF
--- a/changelog.d/20241217_195629_15r10nk-git_fix_sets.md
+++ b/changelog.d/20241217_195629_15r10nk-git_fix_sets.md
@@ -1,0 +1,44 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+### Fixed
+
+- Code generation for sets is now deterministic.
+  ``` python
+  def test():
+      assert {1j, 2j, 1, 2, 3} == snapshot({1, 1j, 2, 2j, 3})
+  ```
+
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/inline_snapshot/_code_repr.py
+++ b/src/inline_snapshot/_code_repr.py
@@ -119,12 +119,27 @@ def _(value: Flag):
     return " | ".join(f"{name}.{flag.name}" for flag in type(value) if flag in value)
 
 
+def sort_set_values(set_values):
+    is_sorted = False
+    try:
+        set_values = sorted(set_values)
+        is_sorted = True
+    except TypeError:
+        pass
+
+    set_values = list(map(repr, set_values))
+    if not is_sorted:
+        set_values = sorted(set_values)
+
+    return set_values
+
+
 @customize_repr
 def _(value: set):
     if len(value) == 0:
         return "set()"
 
-    return "{" + ", ".join(map(repr, value)) + "}"
+    return "{" + ", ".join(sort_set_values(value)) + "}"
 
 
 @customize_repr
@@ -132,7 +147,7 @@ def _(value: frozenset):
     if len(value) == 0:
         return "frozenset()"
 
-    return "frozenset({" + ", ".join(map(repr, value)) + "})"
+    return "frozenset({" + ", ".join(sort_set_values(value)) + "})"
 
 
 @customize_repr

--- a/tests/test_code_repr.py
+++ b/tests/test_code_repr.py
@@ -310,6 +310,16 @@ def test_datatypes(d):
     assert d == eval(code)
 
 
+def test_set():
+    assert code_repr({1, 2, 3, "a", True, "b"}) == snapshot("{'a', 'b', 1, 2, 3}")
+    assert code_repr({1j, 2j, 3j, "a", True, "b"}) == snapshot(
+        "{'a', 'b', 1j, 2j, 3j, True}"
+    )
+    assert code_repr({1, 2, 3, 10, 11, 20, 200}) == snapshot(
+        "{1, 2, 3, 10, 11, 20, 200}"
+    )
+
+
 def test_datatypes_explicit():
     assert code_repr(C(a=1, c=2)) == snapshot("C(a=1, c=2)")
     assert code_repr(B(b=5)) == snapshot("B(b=5)")


### PR DESCRIPTION
- Code generation for sets is now deterministic.
  ``` python
  def test():
      assert {1j, 2j, 1, 2, 3} == snapshot({1, 1j, 2, 2j, 3})
  ```