### PR TITLE
fix: Find pyproject.toml in upper directories

### DIFF
--- a/changelog.d/20241220_221301_Pawamoy_find_pyproject_upper_dirs.md
+++ b/changelog.d/20241220_221301_Pawamoy_find_pyproject_upper_dirs.md
@@ -1,0 +1,40 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+### Fixed
+
+- Find `pyproject.toml` file in parent directories, not just next to the Pytest configuration file.
+
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/inline_snapshot/pytest_plugin.py
+++ b/src/inline_snapshot/pytest_plugin.py
@@ -77,6 +77,8 @@ def pytest_configure(config):
 
     directory = config.rootpath
     while not (pyproject := directory / "pyproject.toml").exists():
+        if directory == directory.parent:
+            break
         directory = directory.parent
     _config.config = _config.read_config(pyproject)
 

--- a/src/inline_snapshot/pytest_plugin.py
+++ b/src/inline_snapshot/pytest_plugin.py
@@ -75,7 +75,10 @@ def is_implementation_supported():
 def pytest_configure(config):
     global flags
 
-    _config.config = _config.read_config(config.rootpath / "pyproject.toml")
+    directory = config.rootpath
+    while not (pyproject := directory / "pyproject.toml").exists():
+        directory = directory.parent
+    _config.config = _config.read_config(pyproject)
 
     if config.option.inline_snapshot is None:
         flags = set(_config.config.default_flags)

--- a/src/inline_snapshot/testing/_example.py
+++ b/src/inline_snapshot/testing/_example.py
@@ -99,10 +99,16 @@ class Example:
 
     def _write_files(self, dir: Path):
         for name, content in self.files.items():
-            (dir / name).write_text(content)
+            filename = dir / name
+            filename.parent.mkdir(exist_ok=True, parents=True)
+            filename.write_text(content)
 
     def _read_files(self, dir: Path):
-        return {p.name: p.read_text() for p in dir.iterdir() if p.is_file()}
+        return {
+            str(p.relative_to(dir)): p.read_text()
+            for p in [*dir.iterdir(), *dir.rglob("*.py")]
+            if p.is_file()
+        }
 
     def run_inline(
         self,

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -1,5 +1,6 @@
-import pytest
 from unittest.mock import MagicMock
+
+import pytest
 from inline_snapshot import snapshot
 from inline_snapshot.testing import Example
 


### PR DESCRIPTION
Previously, the code assumed that pyproject.toml was located next to the Pytest config file, which is not always the case. Now we simply climb up the directory tree to search for the closest pyproject.toml. Let me know if you think of a better approach :slightly_smiling_face: 