### PR TITLE
feat: Add `storage-dir` configuration option

### DIFF
--- a/changelog.d/20241220_120136_Pawamoy_snapshot_dir_config.md
+++ b/changelog.d/20241220_120136_Pawamoy_snapshot_dir_config.md
@@ -12,7 +12,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 -->
 ### Added
 
-- Support for a new `snapshot-dir` configuration option, to tell inline-snapshot where to save external files.
+- Support for a new `storage-dir` configuration option, to tell inline-snapshot where to store data files such as external snapshots.
 
 <!--
 ### Changed

--- a/changelog.d/20241220_120136_Pawamoy_snapshot_dir_config.md
+++ b/changelog.d/20241220_120136_Pawamoy_snapshot_dir_config.md
@@ -1,0 +1,40 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+### Added
+
+- Support for a new `snapshot-dir` configuration option, to tell inline-snapshot where to save external files.
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,6 +19,7 @@ fix=["create","fix"]
 * **shortcuts:** allows you to define custom commands to simplify your workflows.
     `--fix` and `--review` are defined by default, but this configuration can be changed to fit your needs.
 
-* **snapshot-dir:** allows you to define the directory where external files will be stored.
-    By default, it will be `<pytest_config_dir>/.inline-snapshot/external`,
+* **storage-dir:** allows you to define the directory where inline-snapshot stores data files such as external snapshots.
+    By default, it will be `<pytest_config_dir>/.inline-snapshot`,
     where `<pytest_config_dir>` is replaced by the directory containing the Pytest configuration file, if any.
+    External snapshots will be stored in the `external` subfolder.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,4 +22,4 @@ fix=["create","fix"]
 * **storage-dir:** allows you to define the directory where inline-snapshot stores data files such as external snapshots.
     By default, it will be `<pytest_config_dir>/.inline-snapshot`,
     where `<pytest_config_dir>` is replaced by the directory containing the Pytest configuration file, if any.
-    External snapshots will be stored in the `external` subfolder.
+    External snapshots will be stored in the `external` subfolder of the storage directory.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,3 +18,7 @@ fix=["create","fix"]
 
 * **shortcuts:** allows you to define custom commands to simplify your workflows.
     `--fix` and `--review` are defined by default, but this configuration can be changed to fit your needs.
+
+* **snapshot-dir:** allows you to define the directory where external files will be stored.
+    By default, it will be `<pytest_config_dir>/.inline-snapshot/external`,
+    where `<pytest_config_dir>` is replaced by the directory containing the Pytest configuration file, if any.

--- a/src/inline_snapshot/_config.py
+++ b/src/inline_snapshot/_config.py
@@ -5,6 +5,7 @@ from dataclasses import field
 from pathlib import Path
 from typing import Dict
 from typing import List
+from typing import Optional
 
 
 if sys.version_info >= (3, 11):
@@ -18,7 +19,7 @@ class Config:
     hash_length: int = 12
     default_flags: List[str] = field(default_factory=lambda: ["short-report"])
     shortcuts: Dict[str, List[str]] = field(default_factory=dict)
-    snapshot_dir: Path | None = None
+    snapshot_dir: Optional[Path] = None
 
 
 config = Config()

--- a/src/inline_snapshot/_config.py
+++ b/src/inline_snapshot/_config.py
@@ -19,7 +19,7 @@ class Config:
     hash_length: int = 12
     default_flags: List[str] = field(default_factory=lambda: ["short-report"])
     shortcuts: Dict[str, List[str]] = field(default_factory=dict)
-    snapshot_dir: Optional[Path] = None
+    storage_dir: Optional[Path] = None
 
 
 config = Config()
@@ -50,12 +50,12 @@ def read_config(path: Path) -> Config:
                 "shortcuts", {"fix": ["create", "fix"], "review": ["review"]}
             )
 
-            if snapshot_dir := config.get("snapshot-dir"):
-                snapshot_dir = Path(snapshot_dir)
-                if not snapshot_dir.is_absolute():
+            if storage_dir := config.get("storage-dir"):
+                storage_dir = Path(storage_dir)
+                if not storage_dir.is_absolute():
                     # Make it relative to pyproject.toml, and absolute.
-                    snapshot_dir = path.parent.joinpath(snapshot_dir).absolute()
-                result.snapshot_dir = snapshot_dir
+                    storage_dir = path.parent.joinpath(storage_dir).absolute()
+                result.storage_dir = storage_dir
 
     env_var = "INLINE_SNAPSHOT_DEFAULT_FLAGS"
     if env_var in os.environ:

--- a/src/inline_snapshot/_config.py
+++ b/src/inline_snapshot/_config.py
@@ -18,6 +18,7 @@ class Config:
     hash_length: int = 12
     default_flags: List[str] = field(default_factory=lambda: ["short-report"])
     shortcuts: Dict[str, List[str]] = field(default_factory=dict)
+    snapshot_dir: Path | None = None
 
 
 config = Config()
@@ -47,6 +48,13 @@ def read_config(path: Path) -> Config:
             result.shortcuts = config.get(
                 "shortcuts", {"fix": ["create", "fix"], "review": ["review"]}
             )
+
+            if snapshot_dir := config.get("snapshot-dir"):
+                snapshot_dir = Path(snapshot_dir)
+                if not snapshot_dir.is_absolute():
+                    # Make it relative to pyproject.toml, and absolute.
+                    snapshot_dir = path.parent.joinpath(snapshot_dir).absolute()
+                result.snapshot_dir = snapshot_dir
 
     env_var = "INLINE_SNAPSHOT_DEFAULT_FLAGS"
     if env_var in os.environ:

--- a/src/inline_snapshot/_external.py
+++ b/src/inline_snapshot/_external.py
@@ -80,7 +80,7 @@ class external:
 
         The external data is by default stored inside `<pytest_config_dir>/.inline-snapshot/external`,
         where `<pytest_config_dir>` is replaced by the directory containing the Pytest configuration file, if any.
-        To store the data in a different location, set the `snapshot-dir` option in pyproject.toml.
+        To store data in a different location, set the `storage-dir` option in pyproject.toml.
         Data which is outsourced but not referenced in the source code jet has a '-new' suffix in the filename.
 
         Parameters:

--- a/src/inline_snapshot/_external.py
+++ b/src/inline_snapshot/_external.py
@@ -78,8 +78,9 @@ class external:
         """External objects are used as a representation for outsourced data.
         You should not create them directly.
 
-        The external data is stored inside `<pytest_config_dir>/.inline_snapshot/external`,
+        The external data is by default stored inside `<pytest_config_dir>/.inline-snapshot/external`,
         where `<pytest_config_dir>` is replaced by the directory containing the Pytest configuration file, if any.
+        To store the data in a different location, set the `snapshot-dir` option in pyproject.toml.
         Data which is outsourced but not referenced in the source code jet has a '-new' suffix in the filename.
 
         Parameters:

--- a/src/inline_snapshot/pytest_plugin.py
+++ b/src/inline_snapshot/pytest_plugin.py
@@ -113,11 +113,11 @@ def pytest_configure(config):
 
         _inline_snapshot._update_flags = _inline_snapshot.Flags(flags & categories)
 
-    snapshot_path = (
-        _config.config.snapshot_dir or config.rootpath / ".inline-snapshot/external"
-    )
+    external_storage = (
+        _config.config.storage_dir or config.rootpath / ".inline-snapshot"
+    ) / "external"
 
-    _external.storage = _external.DiscStorage(snapshot_path)
+    _external.storage = _external.DiscStorage(external_storage)
 
     if flags - {"short-report", "disable"}:
 

--- a/src/inline_snapshot/pytest_plugin.py
+++ b/src/inline_snapshot/pytest_plugin.py
@@ -113,7 +113,7 @@ def pytest_configure(config):
 
         _inline_snapshot._update_flags = _inline_snapshot.Flags(flags & categories)
 
-    snapshot_path = Path(config.rootpath) / ".inline-snapshot/external"
+    snapshot_path = _config.config.snapshot_dir or config.rootpath / ".inline-snapshot/external"
 
     _external.storage = _external.DiscStorage(snapshot_path)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -321,8 +321,8 @@ def set_time(freezer):
         def write_file(self, filename, content):
             (pytester.path / filename).write_text(content, "utf-8")
 
-        def storage(self):
-            dir = pytester.path / ".inline-snapshot" / "external"
+        def storage(self, snapshot_dir=".inline-snapshot/external"):
+            dir = pytester.path / snapshot_dir
 
             if not dir.exists():
                 return []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -322,7 +322,10 @@ def set_time(freezer):
             (pytester.path / filename).write_text(content, "utf-8")
 
         def storage(self, snapshot_dir=".inline-snapshot/external"):
-            dir = pytester.path / snapshot_dir
+            if os.path.isabs(snapshot_dir):
+                dir = Path(snapshot_dir)
+            else:
+                dir = pytester.path / snapshot_dir
 
             if not dir.exists():
                 return []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -321,11 +321,12 @@ def set_time(freezer):
         def write_file(self, filename, content):
             (pytester.path / filename).write_text(content, "utf-8")
 
-        def storage(self, snapshot_dir=".inline-snapshot/external"):
-            if os.path.isabs(snapshot_dir):
-                dir = Path(snapshot_dir)
+        def storage(self, storage_dir=".inline-snapshot"):
+            if os.path.isabs(storage_dir):
+                dir = Path(storage_dir)
             else:
-                dir = pytester.path / snapshot_dir
+                dir = pytester.path / storage_dir
+            dir /= "external"
 
             if not dir.exists():
                 return []

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -764,4 +764,6 @@ def test_outsource():
     project.run("--inline-snapshot=fix")
     assert result.ret == 0
 
-    assert project.storage(snapshot_dir)
+    assert project.storage(snapshot_dir) == snapshot(
+        ["2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824.html"]
+    )

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -727,7 +727,6 @@ ERROR: --inline-snapshot=creaigflen is a unknown flag
     )
 
 
-
 def test_snapshot_dir_config(project):
     project.pyproject(
         """
@@ -747,14 +746,16 @@ def test_outsource():
 
     result = project.run("--inline-snapshot=create")
     assert result.ret == 0
-    assert project.source == snapshot("""\
+    assert project.source == snapshot(
+        """\
 from inline_snapshot import outsource, snapshot
 
 from inline_snapshot import external
 
 def test_outsource():
     assert outsource("hello", suffix=".html") == snapshot(external("2cf24dba5fb0*.html"))
-""")
+"""
+    )
 
     project.run("--inline-snapshot=fix")
     assert result.ret == 0

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -727,15 +727,17 @@ ERROR: --inline-snapshot=creaigflen is a unknown flag
     )
 
 
-@pytest.mark.parametrize("snapshot_dir", ["tests/snapshots", None])
-def test_snapshot_dir_config(project, tmp_path, snapshot_dir):
-    if not snapshot_dir:
-        snapshot_dir = tmp_path / "snapshots"
+@pytest.mark.parametrize("storage_dir", ["tests/snapshots", None])
+def test_storage_dir_config(project, tmp_path, storage_dir):
+    # Relative path case: `tests/snapshots` (parametrized).
+    # Absolute path case: `tmp_path / "snapshots"` (parametrized as `None`).
+    if not storage_dir:
+        storage_dir = tmp_path / "snapshots"
 
     project.pyproject(
         f"""
 [tool.inline-snapshot]
-snapshot-dir = "{snapshot_dir}"
+storage-dir = "{storage_dir}"
 """
     )
 
@@ -764,6 +766,6 @@ def test_outsource():
     project.run("--inline-snapshot=fix")
     assert result.ret == 0
 
-    assert project.storage(snapshot_dir) == snapshot(
+    assert project.storage(storage_dir) == snapshot(
         ["2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824.html"]
     )

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -727,11 +727,15 @@ ERROR: --inline-snapshot=creaigflen is a unknown flag
     )
 
 
-def test_snapshot_dir_config(project):
+@pytest.mark.parametrize("snapshot_dir", ["tests/snapshots", None])
+def test_snapshot_dir_config(project, tmp_path, snapshot_dir):
+    if not snapshot_dir:
+        snapshot_dir = tmp_path / "snapshots"
+
     project.pyproject(
-        """
+        f"""
 [tool.inline-snapshot]
-snapshot-dir = "tests/snapshots"
+snapshot-dir = "{snapshot_dir}"
 """
     )
 
@@ -760,4 +764,4 @@ def test_outsource():
     project.run("--inline-snapshot=fix")
     assert result.ret == 0
 
-    assert project.storage("tests/snapshots")
+    assert project.storage(snapshot_dir)


### PR DESCRIPTION
Closes #75.

The `Config` class accepts `None` for `snapshot_dir` so that it's backward compatible. We then handle the value in `pytest_configure`, where we use a hardcoded default of `config.rootpath / ".inline-snapshot/external"`. Let me know if there's a better approach.