### PR TITLE
Use sys.executable rather than "python" to invoke pytest

### DIFF
--- a/src/inline_snapshot/testing/_example.py
+++ b/src/inline_snapshot/testing/_example.py
@@ -5,6 +5,7 @@ import os
 import platform
 import re
 import subprocess as sp
+import sys
 import traceback
 from argparse import ArgumentParser
 from io import StringIO
@@ -262,7 +263,7 @@ class Example:
             tmp_path = Path(dir)
             self._write_files(tmp_path)
 
-            cmd = ["python", "-m", "pytest", *args]
+            cmd = [sys.executable, "-m", "pytest", *args]
 
             term_columns = 80
 


### PR DESCRIPTION
This supports environments where the Python interpreter is not named "python". For example, in Fedora it is "python3" unless the `python-unversioned-command` package is installed.