### PR TITLE
fix: report correct pytest diff when --inline-snapshot=report -vv is used

### DIFF
--- a/changelog.d/20250413_210056_15r10nk-git_fix_pytest_diff.md
+++ b/changelog.d/20250413_210056_15r10nk-git_fix_pytest_diff.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- show correct diff when `pytest --inline-snapshot=report -vv` is used (#231)

--- a/src/inline_snapshot/fix_pytest_diff.py
+++ b/src/inline_snapshot/fix_pytest_diff.py
@@ -1,0 +1,50 @@
+from typing import IO
+from typing import Any
+from typing import Set
+
+from inline_snapshot._is import Is
+from inline_snapshot._snapshot.generic_value import GenericValue
+from inline_snapshot._unmanaged import Unmanaged
+
+
+def fix_pytest_diff():
+    from _pytest._io.pprint import PrettyPrinter
+
+    def _pprint_snapshot(
+        self,
+        object: Any,
+        stream: IO[str],
+        indent: int,
+        allowance: int,
+        context: Set[int],
+        level: int,
+    ) -> None:
+        self._format(object._old_value, stream, indent, allowance, context, level)
+
+    PrettyPrinter._dispatch[GenericValue.__repr__] = _pprint_snapshot
+
+    def _pprint_unmanaged(
+        self,
+        object: Any,
+        stream: IO[str],
+        indent: int,
+        allowance: int,
+        context: Set[int],
+        level: int,
+    ) -> None:
+        self._format(object.value, stream, indent, allowance, context, level)
+
+    PrettyPrinter._dispatch[Unmanaged.__repr__] = _pprint_unmanaged
+
+    def _pprint_is(
+        self,
+        object: Any,
+        stream: IO[str],
+        indent: int,
+        allowance: int,
+        context: Set[int],
+        level: int,
+    ) -> None:
+        self._format(object.value, stream, indent, allowance, context, level)
+
+    PrettyPrinter._dispatch[Is.__repr__] = _pprint_is

--- a/src/inline_snapshot/pytest_plugin.py
+++ b/src/inline_snapshot/pytest_plugin.py
@@ -11,6 +11,8 @@ from rich.panel import Panel
 from rich.prompt import Confirm
 from rich.syntax import Syntax
 
+from inline_snapshot.fix_pytest_diff import fix_pytest_diff
+
 from . import _config
 from . import _external
 from . import _find_external
@@ -184,6 +186,8 @@ def pytest_configure(config):
         ]
 
     pydantic_fix()
+
+    fix_pytest_diff()
 
     state().storage.prune_new_files()
 

--- a/src/inline_snapshot/testing/_example.py
+++ b/src/inline_snapshot/testing/_example.py
@@ -224,6 +224,7 @@ class Example:
         env: dict[str, str] = {},
         changed_files: Snapshot[dict[str, str]] | None = None,
         report: Snapshot[str] | None = None,
+        error: Snapshot[str] | None = None,
         stderr: Snapshot[str] | None = None,
         returncode: Snapshot[int] = 0,
         stdin: bytes = b"",
@@ -319,6 +320,19 @@ class Example:
                 report_str = "\n".join(report_list)
 
                 assert report_str == report, repr(report_str)
+
+            if error is not None:
+                assert (
+                    error
+                    == "\n".join(
+                        [
+                            line
+                            for line in result_stdout.splitlines()
+                            if line and line[:2] in ("> ", "E ")
+                        ]
+                    )
+                    + "\n"
+                )
 
             if changed_files is not None:
                 current_files = {}

--- a/tests/test_pytest_diff_fix.py
+++ b/tests/test_pytest_diff_fix.py
@@ -1,0 +1,70 @@
+import pytest
+from executing import is_pytest_compatible
+
+from inline_snapshot import snapshot
+from inline_snapshot.testing._example import Example
+
+
+@pytest.mark.skipif(
+    not is_pytest_compatible(),
+    reason="pytest assert rewriting and report can not be used at the same time",
+)
+def test_pytest_diff_fix():
+
+    Example(
+        """\
+from inline_snapshot import snapshot,Is
+
+
+def test_dict_report():
+    usd = snapshot({"name": "US Dollar", "code": "USD", "symbol": "$"})
+    usd2 = Is([1,2])
+
+    price = {
+        "amount": 1,
+        "currency": {
+            "code": "USD",
+            "name": "US Dollar",
+            "symbol": "$",
+        },
+        "b":[1,2]
+    }
+
+    assert price == snapshot({
+        "amount": 2,
+        "currency": usd,
+        "b":usd2
+    })
+"""
+    ).run_pytest(
+        ["--inline-snapshot=report", "-vv"],
+        error=snapshot(
+            """\
+>       assert price == snapshot({
+E       AssertionError: assert {'amount': 1, 'currency': {'code': 'USD', 'name': 'US Dollar', 'symbol': '$'}, 'b': [1, 2]} == {'amount': 2, 'currency': {'name': 'US Dollar', 'code': 'USD', 'symbol': '$'}, 'b': [1, 2]}
+E         \n\
+E         Common items:
+E         {'b': [1, 2], 'currency': {'code': 'USD', 'name': 'US Dollar', 'symbol': '$'}}
+E         Differing items:
+E         {'amount': 1} != {'amount': 2}
+E         \n\
+E         Full diff:
+E           {
+E         -     'amount': 2,
+E         ?               ^
+E         +     'amount': 1,
+E         ?               ^
+E               'b': [
+E                   1,
+E                   2,
+E               ],
+E               'currency': {
+E                   'code': 'USD',
+E                   'name': 'US Dollar',
+E                   'symbol': '$',
+E               },
+E           }
+"""
+        ),
+        returncode=1,
+    )


### PR DESCRIPTION
solves #231  