### PR TITLE
hide updates by default

### DIFF
--- a/changelog.d/20250425_184256_15r10nk-git_enable_update.md
+++ b/changelog.d/20250425_184256_15r10nk-git_enable_update.md
@@ -1,0 +1,3 @@
+### Changed
+
+- snapshot updates are now disabled by default. They be enabled with `show-updates=true` in your config. This is done because they can confuse new inline-snapshot users and does not fit the way how most users work with inline-snapshot. updates will become much more useful when (#177) is implemented.

--- a/docs/categories.md
+++ b/docs/categories.md
@@ -183,7 +183,9 @@ It is recommended to use trim only if you run your complete test suite.
 
 ### Update
 
-Changes in the update category do not change the value in the code, just the representation. The reason might be that `#!python repr()` of the object has changed or that inline-snapshot provides some new logic which changes the representation. Like with the strings in the following example:
+Changes in the update category do not change the value of the snapshot, just its representation.
+These updates are not shown by default in your reports and can be enabled with [show-updates](configuration.md/#show-updates).
+The reason might be that `#!python repr()` of the object has changed or that inline-snapshot provides some new logic which changes the representation. Like with the strings in the following example:
 
 
 === "original"
@@ -254,8 +256,6 @@ Changes in the update category do not change the value in the code, just the rep
 
 The approval of this type of changes is easier, because inline-snapshot assures that the value has not changed.
 
-It is not necessary, but recommended to make these changes for the following reason:
-
 The goal of inline-snapshot is to generate the values for you in the correct format so that no manual editing is required.
 This improves your productivity and saves time.
 Keep in mind that any changes you make to your snapshots will likely need to be redone if your program's behaviour (and expected values) change.
@@ -269,3 +269,6 @@ You can agree with inline-snapshot and accept the changes or you can use one of 
 3. inline-snapshot manages everything within `snapshot(...)`, but you can take control by using [Is()](eq_snapshot.md#is) in cases where you want to use custom code (like local variables) in your snapshots.
 
 4. you can also open an [issue](https://github.com/15r10nk/inline-snapshot/issues?q=is%3Aissue%20state%3Aopen%20label%3Aupdate_related) if you have a specific problem with the way inline-snapshot generates the code.
+
+!!! note:
+    [#177](https://github.com/15r10nk/inline-snapshot/issues/177) will give the developer more control about how snapshots are created. *update* will them become much more useful.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,7 +6,7 @@ hash-length=15
 default-flags=["report"]
 default-flags-tui=["create", "review"]
 format-command=""
-skip-snapshot-updates-for-now=false
+show-updates=false
 
 [tool.inline-snapshot.shortcuts]
 review=["review"]
@@ -56,6 +56,4 @@ fix=["create","fix"]
     format-command="ruff check --fix-only --stdin-filename {filename} | ruff format --stdin-filename {filename}"
     ```
 
-* **skip-snapshot-updates-for-now:** allows you to skip the reporting of updates.
-    Please create an new [issue](https://github.com/15r10nk/inline-snapshot/issues?q=is%3Aissue%20state%3Aopen%20label%3Aupdate_related) if you think the snapshot value which was generated can be improved.
-    This option might be removed in the future when inline-snapshot has better capabilities to customize the way snapshots are generated.
+* **show-updates:**[](){#show-updates} shows updates in reviews and reports.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,3 +211,6 @@ markers=["no_rewriting: marks tests which need no code rewriting and can be used
 [tool.isort]
 profile="black"
 force_single_line=true
+
+[tool.inline-snapshot]
+show-updates=true

--- a/src/inline_snapshot/_config.py
+++ b/src/inline_snapshot/_config.py
@@ -20,7 +20,7 @@ class Config:
     shortcuts: Dict[str, List[str]] = field(default_factory=dict)
     format_command: Optional[str] = None
     storage_dir: Optional[Path] = None
-    skip_snapshot_updates_for_now: bool = False
+    show_updates: bool = False
 
 
 config = Config()
@@ -53,9 +53,7 @@ def read_config(path: Path, config=Config()) -> Config:
         pass
 
     try:
-        config.skip_snapshot_updates_for_now = tool_config[
-            "skip-snapshot-updates-for-now"
-        ]
+        config.show_updates = tool_config["show-updates"]
     except KeyError:
         pass
 

--- a/src/inline_snapshot/pytest_plugin.py
+++ b/src/inline_snapshot/pytest_plugin.py
@@ -292,9 +292,7 @@ def call_once(f):
 
 
 def link(text, link=None):
-    if link is None:
-        link = text
-    return f"[italic blue link={link}]{text}[/]"
+    return f"[italic blue link={link or text}]{text}[/]"
 
 
 def category_link(category):
@@ -450,19 +448,9 @@ def pytest_sessionfinish(session, exitstatus):
 
                 if (
                     flag == "update"
-                    and _config.config.skip_snapshot_updates_for_now
+                    and not _config.config.show_updates
                     and not "update" in state().flags
                 ):
-                    console().print(
-                        f"{len(changes[flag])} updates are hidden. "
-                        f"Please report why you do not want these updates so that inline-snapshot can create better snapshots in the future."
-                    )
-                    console().print("You can find more information about updates here:")
-                    console().print(
-                        link(
-                            "https://15r10nk.github.io/inline-snapshot/latest/categories/#update"
-                        )
-                    )
                     continue
 
                 cr = ChangeRecorder()

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -302,6 +302,13 @@ def test_a():
 """
     )
 
+    project.pyproject(
+        """
+[tool.inline-snapshot]
+show-updates=true
+"""
+    )
+
     result = project.run("--inline-snapshot=trim,report")
 
     assert result.report == snapshot(

--- a/tests/test_skip_updates.py
+++ b/tests/test_skip_updates.py
@@ -2,22 +2,14 @@ from inline_snapshot import snapshot
 from inline_snapshot.testing._example import Example
 
 
-def test_skip_snapshot_updates():
+def test_use_snapshot_updates():
 
-    expected_report = snapshot(
-        """\
-1 updates are hidden. Please report why you do not want these updates so that
-inline-snapshot can create better snapshots in the future.
-You can find more information about updates here:
-https://15r10nk.github.io/inline-snapshot/latest/categories/#update\
-"""
-    )
+    expected_report = snapshot("")
 
     Example(
         {
             "pyproject.toml": f"""\
 [tool.inline-snapshot]
-skip-snapshot-updates-for-now=true
 """,
             "test_a.py": """\
 from inline_snapshot import snapshot

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -20,6 +20,7 @@ print(text,end="")
             "pyproject.toml": f"""\
 [tool.inline-snapshot]
 format-command="{executable} fmt_cmd.py {{filename}}"
+show-updates=true
 """,
             "test_a.py": """\
 from inline_snapshot import snapshot


### PR DESCRIPTION
The difference between update and fix is confusing for first time users.

I changed the implementation in this way that it will ignore updates by default.

show-updates=True will show them
show-updates=False will hide them (the default now).

Updates will get more useful once #177 is implemented.
