### PR TITLE
fix: Remove spurious new uuid7 dependency

### DIFF
--- a/changelog.d/20250723_221049_code_no_uuid7.md
+++ b/changelog.d/20250723_221049_code_no_uuid7.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+### Changed
+
+- Removed unnecessary uuid7 dependency introduced in 0.25.0
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
   "rich>=13.7.1",
   "tomli>=2.0.0; python_version < '3.11'",
   "pytest>=8.3.4",
-  "uuid7>=0.1.0",
 ]
 description = "golden master/snapshot/approval testing library which puts the values right into your source code"
 keywords = []


### PR DESCRIPTION
The [`uuid7`](https://pypi.org/project/uuid7/) dependency was added in https://github.com/15r10nk/inline-snapshot/pull/224, but nothing actually imports from the `uuid_extensions` module it provides. This is probably just as well, since https://github.com/stevesimmons/uuid7/issues/1 suggests it has issues.

## Description
<!--
Please provide a clear and concise description of what this pull request does.
Create an issue first if you want to make bigger changes.
-->
This PR removes the spurious/unused dependency on the `uuid7` package.

## Related Issue(s)
<!--
- Closes #123 (replace with relevant issue number(s), if applicable)
- Related to #456
-->

## Checklist
- [x] I have tested my changes thoroughly (you can download the test coverage with `hatch run cov:github`).
- [x] I have added/updated relevant documentation. **N/A**
- [x] I have added tests for new functionality (if applicable). **N/A**
- [x] I have reviewed my own code for errors. **N/A, no code changes**
- [x] I have added a changelog entry with `hatch run changelog:entry`
- [x] I used semantic commits (`feat:` will cause a major and `fix:` a minor version bump)
- [x] You can squash you commits, otherwise they will be squashed during merge
