### PR TITLE
ci: skip development docs deployment for version tags

### DIFF
--- a/.github/workflows/deploy_development_docs.yml
+++ b/.github/workflows/deploy_development_docs.yml
@@ -2,6 +2,8 @@ name: deploy development docs
 on:
   push:
     branches: [main]
+    tags-ignore:
+    - v[0-9]+.[0-9]+.[0-9]+
 
 jobs:
   build:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,3 +22,4 @@ jobs:
         git config user.email "15r10nk@users.noreply.github.com"
         git fetch origin gh-pages --depth=1
         hatch run docs:mike deploy -u --push ${INLINE_SNAPSHOT_VERSION} latest
+        hatch run docs:mike deploy -u --push development


### PR DESCRIPTION
## Description
<!--
Please provide a clear and concise description of what this pull request does.
Create an issue first if you want to make bigger changes.
-->

it is a problem if two jobs want to deploy the docs at the same time. this pr tries to fix this by excluding version tags for one of them.

## Related Issue(s)
<!--
- Closes #123 (replace with relevant issue number(s), if applicable)
- Related to #456
-->

## Checklist
- [ ] I have tested my changes thoroughly (you can download the test coverage with `hatch run cov:github`).
- [ ] I have added/updated relevant documentation.
- [ ] I have added tests for new functionality (if applicable).
- [x] I have reviewed my own code for errors.
- [ ] I have added a changelog entry with `hatch run changelog:entry`
- [ ] I used semantic commits (`feat:` will cause a major and `fix:` a minor version bump)
- [ ] You can squash you commits, otherwise they will be squashed during merge
