### PR TITLE
chore(types): add explicit type hints to outsource function

### DIFF
--- a/changelog.d/20250807_105409_robert_outsource_types.md
+++ b/changelog.d/20250807_105409_robert_outsource_types.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+### Fixed
+
+- Added explicit type hints to the `outsource()` function
+
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/inline_snapshot/_external/_outsource.py
+++ b/src/inline_snapshot/_external/_outsource.py
@@ -47,7 +47,7 @@ class Outsourced:
         return self.data
 
 
-def outsource(data, suffix: str | None = None):
+def outsource(data: Any, suffix: str | None = None) -> Any:
     if suffix and suffix[0] != ".":
         raise ValueError("suffix has to start with a '.' like '.png'")
 


### PR DESCRIPTION
## Description

linters like Pyright will complain, when used in strict mode, if any symbols you use don't have explicit type hints.

## Checklist
- [ ] I have tested my changes thoroughly (you can download the test coverage with `hatch run cov:github`).
- [ ] I have added/updated relevant documentation.
- [ ] I have added tests for new functionality (if applicable).
- [x] I have reviewed my own code for errors.
- [x] I have added a changelog entry with `hatch run changelog:entry`
- [x] I used semantic commits (`feat:` will cause a major and `fix:` a minor version bump)
- [ ] You can squash you commits, otherwise they will be squashed during merge
