### PR TITLE
fix: disable ensure_ascii for json.dump

### DIFF
--- a/changelog.d/20251020_111016_a.kiverin_disable_ensure_ascii_json.md
+++ b/changelog.d/20251020_111016_a.kiverin_disable_ensure_ascii_json.md
@@ -1,0 +1,40 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+### Fixed
+
+- Disable ensure ascii in json.dump to support non-ASCII characters in external files
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/inline_snapshot/_external/_format/_json.py
+++ b/src/inline_snapshot/_external/_format/_json.py
@@ -34,7 +34,7 @@ class JsonFormat(TextDiff, Format[object]):
     def encode(self, value: object, path: Path):
 
         with path.open("w", newline="\n", encoding="utf-8") as f:
-            json.dump(value, f, indent=2)
+            json.dump(value, f, indent=2, ensure_ascii=False)
 
     def decode(self, path: Path) -> object:
 

--- a/tests/external/test_formats.py
+++ b/tests/external/test_formats.py
@@ -41,6 +41,46 @@ def test_a():
     )
 
 
+def test_json_format_with_non_ascii_symbols():
+
+    Example(
+        """\
+from inline_snapshot import external
+
+def test_a():
+    assert ["Тест1","Тест2"] == external(".json")
+    assert {"Тест":2} == external()
+"""
+    ).run_inline(
+        ["--inline-snapshot=create"],
+        changed_files=snapshot(
+            {
+                "tests/__inline_snapshot__/test_something/test_a/e3e70682-c209-4cac-a29f-6fbed82c07cd.json": """\
+[
+  "Тест1",
+  "Тест2"
+]\
+""",
+                "tests/__inline_snapshot__/test_something/test_a/f728b4fa-4248-4e3a-8a5d-2f346baa9455.json": """\
+{
+  "Тест": 2
+}\
+""",
+                "tests/test_something.py": """\
+from inline_snapshot import external
+
+def test_a():
+    assert ["Тест1","Тест2"] == external("uuid:e3e70682-c209-4cac-a29f-6fbed82c07cd.json")
+    assert {"Тест":2} == external("uuid:f728b4fa-4248-4e3a-8a5d-2f346baa9455.json")
+""",
+            }
+        ),
+    ).run_inline(
+        ["--inline-snapshot=disable"]
+    )
+
+
+
 def test_binary_format():
 
     Example(


### PR DESCRIPTION
## Description
This PR disables the `ensure_ascii` parameter in `json.dump()` to allow non-ASCII characters to be stored in their readable form in external JSON files, instead of being escaped as Unicode sequences.

Previously, non-ASCII characters like Cyrillic text were stored as escape sequences (e.g., `\u0422\u0435\u0441\u0442`). Now they are preserved in their original readable form (e.g., `Тест`), making the external JSON files more human-readable.

## Example

**Before:**
```json
{
  "message": "\u0422\u0435\u0441\u0442"
}
```

**After:**
```json
{
  "message": "Тест"
}
```


## Related Issue(s)

## Checklist
- [x] I have tested my changes thoroughly (you can download the test coverage with `hatch run cov:github`).
- [ ] I have added/updated relevant documentation.
- [x] I have added tests for new functionality (if applicable).
- [x] I have reviewed my own code for errors.
- [x] I have added a changelog entry with `hatch run changelog:entry`
- [x] I used semantic commits (`feat:` will cause a major and `fix:` a minor version bump)
- [ ] You can squash you commits, otherwise they will be squashed during merge
