### PR TITLE
fix: allow dynamic storages in ExternalLocation.from_name

### DIFF
--- a/src/inline_snapshot/_external/_external_base.py
+++ b/src/inline_snapshot/_external/_external_base.py
@@ -65,9 +65,9 @@ class ExternalBase:
 
         if self._is_empty():
             self._assign(other)
-            state().missing_values += 1
             if state().update_flags.create:
                 return True
+            state().missing_values += 1
             return False
 
         value = self._load_value()

--- a/src/inline_snapshot/_external/_external_base.py
+++ b/src/inline_snapshot/_external/_external_base.py
@@ -70,8 +70,13 @@ class ExternalBase:
             state().missing_values += 1
             return False
 
-        value = self._load_value()
-        result = value == other
+            # Use storage's compare method if available, otherwise fall back to default
+            if hasattr(self.storage, "compare"):
+                result = self.storage.compare(self._location, other)
+            else:
+                # Fallback for storage implementations that don't have compare yet
+                value = self._load_value()
+                result = value == other
 
         if not result and first_comparison:
             self._assign(other)

--- a/src/inline_snapshot/_external/_external_location.py
+++ b/src/inline_snapshot/_external/_external_location.py
@@ -62,8 +62,11 @@ class ExternalLocation(Location):
                 path = name
             elif ":" in name:
                 storage, path = name.split(":", 1)
-                if storage not in ("hash", "uuid"):
-                    raise ValueError(f"storage has to be hash or uuid")
+                if storage not in state().all_storages:
+                    available = ", ".join(map(repr, state().all_storages.keys()))
+                    raise ValueError(
+                        f"storage '{storage}' is not registered. Available: {available}"
+                    )
             else:
                 storage = state().config.default_storage
                 path = name

--- a/src/inline_snapshot/_external/_storage/_protocol.py
+++ b/src/inline_snapshot/_external/_storage/_protocol.py
@@ -17,6 +17,21 @@ class StorageLookupError(Exception):
 
 
 class StorageProtocol:
+    # Does not need to be defined, has a default implementation
+    def compare(self, location: ExternalLocation, other_value) -> bool:
+        """
+        Compare a value against what's stored at the location.
+
+        Default implementation loads the stored value and uses ==.
+        Override this for custom comparison logic (e.g., perceptual hashing).
+
+        Returns:
+            True if the values match according to this storage's criteria
+        """
+        # Default implementation for backward compatibility
+        with self.load(location) as path:
+            stored_value = self._deserialize(path)  # needs to be defined
+            return stored_value == other_value
 
     @contextmanager
     def load(self, location: ExternalLocation) -> Generator[Path]:

--- a/tests/external/test_external_location.py
+++ b/tests/external/test_external_location.py
@@ -4,7 +4,6 @@ from inline_snapshot.testing._example import Example
 
 
 def test_external_location():
-
     results = snapshot(
         {
             "hash:a.txt": ExternalLocation(
@@ -39,12 +38,12 @@ def test_external_location():
             """""": ExternalLocation(
                 storage="uuid", stem="", suffix="", filename=None, qualname=None
             ),
-            "invalid:a.txt": "ValueError: storage has to be hash or uuid",
-            "invalid:a.b.txt": "ValueError: storage has to be hash or uuid",
-            "invalid:a": "ValueError: storage has to be hash or uuid",
-            "invalid:.txt": "ValueError: storage has to be hash or uuid",
-            "invalid:.b.txt": "ValueError: storage has to be hash or uuid",
-            "invalid:": "ValueError: storage has to be hash or uuid",
+            "invalid:a.txt": "ValueError: storage 'invalid' is not registered. Available: 'hash', 'uuid'",
+            "invalid:a.b.txt": "ValueError: storage 'invalid' is not registered. Available: 'hash', 'uuid'",
+            "invalid:a": "ValueError: storage 'invalid' is not registered. Available: 'hash', 'uuid'",
+            "invalid:.txt": "ValueError: storage 'invalid' is not registered. Available: 'hash', 'uuid'",
+            "invalid:.b.txt": "ValueError: storage 'invalid' is not registered. Available: 'hash', 'uuid'",
+            "invalid:": "ValueError: storage 'invalid' is not registered. Available: 'hash', 'uuid'",
         }
     )
 


### PR DESCRIPTION
# 1. Dynamic Storage Backends

## Description

As discussed in #311 (discussion) I am building a prototype of the `phash:` storage protocol for
`ExternalLocation` so we can write `external("phash:")` and have a file be saved to
content-addressable storage using a perceptual hash rather than a cryptographic one, and this will
effectively serve as deduplication as well as a novel way to tolerate inexact matches in file
content in a snapshot.

To add this we discussed changing the validation from hardocing hash and uuid strings to instead
validate against `state().all_storages` whose keys would provide the set of possible storage
protocol prefixes.

This PR does so, and changes the error message from

> ValueError: storage has to be hash or uuid                                                                                                                                                                                                

to

> ValueError: storage 'phash' is not registered. Available: 'hash', 'uuid'

```py
available = ", ".join(map(repr, state().all_storages.keys()))
raise ValueError(
    f"storage '{storage}' is not registered. Available: {available}"
)
```

- I comma separate the `repr` of the string keys rather than the keys themselves to wrap them in single quotes
  which I expect to be clearer even if there are unfamiliar ones.

# 2. Storage Protocol compare method

As a secondary part of the same work, I also needed a `compare` method on StorageProtocol to make mine work, which was discussed [here](https://github.com/15r10nk/inline-snapshot/discussions/311#discussioncomment-14736460_)

> We should also change how `==` works currently for external snapshots. It currently loads the value from disc and compares it. StorageProtocol needs an API to customize the comparison.

# 3. Don't increment `missing_values` in `External` base class `__eq__` method if in create mode

- As in #314 

Nudge the increment line to after create so as not to break the test in teardown if it was just created

## Related Issue(s)

- https://github.com/15r10nk/inline-snapshot/discussions/311

## Checklist
- [ ] I have tested my changes thoroughly (you can download the test coverage with `hatch run cov:github`).
  - I presume it won't but I have not tried setting up the test suite yet
- [ ] I have added/updated relevant documentation.
  - **TODO**
- <strike>[x] I have added tests for new functionality (if applicable).</strike> N/A
- [x] I have reviewed my own code for errors.
  - Very minor change and checked it works with [lmmx/inline-snapshot-phash](https://github.com/lmmx/inline-snapshot-phash)
- [ ] I have added a changelog entry with `hatch run changelog:entry`
  - **TODO**
- [ ] I used semantic commits (`feat:` will cause a major and `fix:` a minor version bump)
  - **TODO**: amend commit to `fix:` and force push overwrite
- [x] You can squash you commits, otherwise they will be squashed during merge
