### PR TITLE
fix format command 320

### DIFF
--- a/changelog.d/20251107_062114_15r10nk-git_discord_chat.md
+++ b/changelog.d/20251107_062114_15r10nk-git_discord_chat.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Format commands with pipelines (using `|`) now properly fail when any command in the pipeline returns a non-zero exit code ([#320](https://github.com/15r10nk/inline-snapshot/issues/320)). Previously, only the last command's exit code was considered, which could allow formatting to succeed even when intermediate commands failed.

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -163,14 +163,18 @@ def test_format_command_fail():
 
     Example(
         {
-            "fmt_cmd.py": """
+            "fmt_cmd_good.py": """
 import sys
-sys.stdout.buffer.write(b"some problem\\n")
+sys.stdout.buffer.write(sys.stdin.buffer.read())
+""",
+            "fmt_cmd_bad.py": """
+import sys
+sys.stdout.buffer.write(b"some_problem\\n")
 sys.exit(1)
 """,
             "pyproject.toml": f"""\
 [tool.inline-snapshot]
-format-command="{executable} fmt_cmd.py {{filename}}"
+format-command="{executable} fmt_cmd_bad.py {{filename}} | {executable} fmt_cmd_good.py"
 """,
             "tests/test_a.py": """
 from inline_snapshot import snapshot
@@ -208,12 +212,12 @@ def test_a():
 +------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 These changes will be applied, because you used fix
 ----------------------------------------------------------------------------------------------- Problems -----------------------------------------------------------------------------------------------
-The format_command '/.../python fmt_cmd.py /.../test_a.py' caused the following error:
-some problem\
+The format_command '/.../python fmt_cmd_bad.py /.../test_a.py | /.../python fmt_cmd_good.py' caused the following error:
+some_problem\
 """
             )
         ),
-        returncode=1,
+        returncode=snapshot(1),
     )
 
 


### PR DESCRIPTION
## Description
- fix: fix pipeline handling in format-command

## Related Issue(s)
- closes #320

## Checklist
- [ ] I have tested my changes thoroughly (you can download the test coverage with `hatch run cov:github`).
- [ ] I have added/updated relevant documentation.
- [ ] I have added tests for new functionality (if applicable).
- [ ] I have reviewed my own code for errors.
- [ ] I have added a changelog entry with `hatch run changelog:entry`
- [ ] I used semantic commits (`feat:` will cause a major and `fix:` a minor version bump)
- [ ] You can squash you commits, otherwise they will be squashed during merge
