### PR TITLE
fix: get_snapshot_value returns old_value

### DIFF
--- a/changelog.d/20260207_234758_qdewaghe_get_snapshot_value.md
+++ b/changelog.d/20260207_234758_qdewaghe_get_snapshot_value.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `get_snapshot_value` now works even if no assertions were made on the snapshot.

--- a/src/inline_snapshot/_get_snapshot_value.py
+++ b/src/inline_snapshot/_get_snapshot_value.py
@@ -15,7 +15,7 @@ from ._unmanaged import Unmanaged
 
 def unwrap(value):
     if isinstance(value, GenericValue):
-        return adapter_map(value._visible_value(), lambda v: unwrap(v)[0]), True
+        return adapter_map(value._old_value, lambda v: unwrap(v)[0]), True
 
     if isinstance(value, (External, Outsourced, ExternalFile)):
         try:

--- a/tests/test_get_snapshot_value.py
+++ b/tests/test_get_snapshot_value.py
@@ -87,3 +87,7 @@ def test_dataclass(try_snapshot_disable):
     assert s == A(a=outsource(5), b=2)
 
     assert inspect(get_snapshot_value(s)) == snapshot("A(a=5, b=2)")
+
+
+def test_no_assert():
+    assert get_snapshot_value(snapshot([])) == []


### PR DESCRIPTION
Maybe I'm misunderstanding this but I would expect `get_snapshot_value` to return the snapshot value even if no assertion has been made yet.

## Description

`get_snapshot_value` used to return `...` if the snapshot was not asserted.
Now, it returns the old value if there is one. Returning the old value should be fine because if the new value does not match the old then a prior assertion has failed.

## Related Issue(s)

#336

## Checklist
- [ ] I have tested my changes thoroughly (you can download the test coverage with `hatch run cov:github`).
- [ ] I have added/updated relevant documentation.
- [ ] I have added tests for new functionality (if applicable).
- [ ] I have reviewed my own code for errors.
- [ ] I have added a changelog entry with `hatch run changelog:entry`
- [ ] I used semantic commits (`feat:` will cause a major and `fix:` a minor version bump)
- [ ] You can squash you commits, otherwise they will be squashed during merge
