### PR TITLE
UsageError("unmanaged values can not be compared with snapshots") when using -k flag #355

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,24 @@
+# Copilot Instructions
+
+## Changelog entries
+
+To create a new changelog entry, run:
+
+```
+uvx scriv create --add
+```
+
+This creates a new Markdown file in `changelog.d/` and stages it with git.
+Then fill in the relevant section(s) in that file. The default template contains
+headers for **Added**, **Changed**, **Fixed**, and **Removed** — delete the ones
+that don't apply and write one or two sentences under the relevant header.
+
+Example result in `changelog.d/<fragment>.md`:
+
+```markdown
+### Fixed
+
+- Fixed snapshot comparison for external files when `_changes()` raises during report generation.
+```
+
+Do **not** edit `CHANGELOG.md` directly — that file is assembled from fragments via `scriv collect`.

--- a/changelog.d/20260301_000000_frank.md
+++ b/changelog.d/20260301_000000_frank.md
@@ -1,0 +1,7 @@
+### Added
+
+- Added `context_managers` parameter to `Example.run_inline()`, allowing tests to inject context managers (e.g. `unittest.mock.patch`) that are active during `show_report()`.
+
+### Fixed
+
+- Fixed `UsageError("unmanaged values can not be compared with snapshots")` raised during session teardown when using `-k` to filter tests ([#355](https://github.com/15r10nk/inline-snapshot/issues/355)). This was caused by inline-snapshot trying to update snapshots that were never compared. This is a rare edge case that caused problems when matchers were used, so it has been removed.

--- a/src/inline_snapshot/_inline_snapshot.py
+++ b/src/inline_snapshot/_inline_snapshot.py
@@ -3,6 +3,7 @@ import inspect
 from typing import Any
 from typing import Iterator
 from typing import TypeVar
+from typing import cast
 
 from inline_snapshot._adapter_context import AdapterContext
 from inline_snapshot._customize._custom_undefined import CustomUndefined
@@ -114,12 +115,18 @@ class SnapshotReference(SnapshotRefBase):
     def create_raw(obj, context: AdapterContext):
         return obj
 
+    def __repr__(self):
+        if self._expr:
+            return ast.unparse(self._expr.node)
+        else:
+            return "snapshot(...)"
+
     def _changes(self) -> Iterator[ChangeBase]:
 
         if (
             isinstance(self._value._old_value, CustomUndefined)
             if self._expr is None
-            else not self._expr.node.args
+            else not cast(ast.Call, self._expr.node).args
         ):
 
             if isinstance(self._value._new_value, CustomUndefined):
@@ -130,7 +137,9 @@ class SnapshotReference(SnapshotRefBase):
             yield CallArg(
                 flag="create",
                 file=self._value._file,
-                node=self._expr.node if self._expr is not None else None,
+                node=(
+                    cast(ast.Call, self._expr.node) if self._expr is not None else None
+                ),
                 arg_pos=0,
                 arg_name=None,
                 new_code=new_code,

--- a/src/inline_snapshot/_snapshot/undecided_value.py
+++ b/src/inline_snapshot/_snapshot/undecided_value.py
@@ -14,7 +14,6 @@ from inline_snapshot._customize._custom_sequence import CustomList
 from inline_snapshot._customize._custom_sequence import CustomTuple
 from inline_snapshot._customize._custom_undefined import CustomUndefined
 from inline_snapshot._customize._custom_unmanaged import CustomUnmanaged
-from inline_snapshot._new_adapter import NewAdapter
 from inline_snapshot._new_adapter import warn_star_expression
 from inline_snapshot._unmanaged import is_unmanaged
 
@@ -141,15 +140,8 @@ class UndecidedValue(GenericValue):
         assert False
 
     def _get_changes(self) -> Iterator[ChangeBase]:
-        assert isinstance(self._new_value, CustomUndefined)
-
-        new_value = self.to_custom(self._old_value._eval())
-
-        adapter = NewAdapter(self._context)
-
-        for change in adapter.compare(self._old_value, self._ast_node, new_value):
-            assert change.flag == "update", change
-            yield change
+        yield from ()
+        return
 
     def __eq__(self, other):
         if compare_only():

--- a/src/inline_snapshot/_snapshot_session.py
+++ b/src/inline_snapshot/_snapshot_session.py
@@ -1,3 +1,4 @@
+import ast
 import os
 import sys
 import tokenize
@@ -6,6 +7,7 @@ from types import FunctionType
 from types import SimpleNamespace
 from typing import Dict
 from typing import List
+from typing import cast
 
 from executing import is_pytest_compatible
 from rich import box
@@ -425,7 +427,25 @@ class SnapshotSession:
 
         for snapshot in state().snapshots.values():
             all_categories = set()
-            for change in snapshot._changes():
+            try:
+                change_list = list(snapshot._changes())
+            except Exception as exception:
+                context = ""
+                if expr := getattr(snapshot, "_expr", None):
+                    code = expr.frame.f_code
+                    context = f"""
+file: {code.co_filename}
+line: {cast(ast.expr,expr.node).lineno}\
+"""
+                raise RuntimeError(
+                    f"""
+error during change collection for snapshot ({snapshot})
+snapshot.\
+{context}
+"""
+                ) from exception
+
+            for change in change_list:
                 changes[change.flag].append(change)
                 all_categories.add(change.flag)
 

--- a/src/inline_snapshot/_types.py
+++ b/src/inline_snapshot/_types.py
@@ -2,8 +2,11 @@
 
 from typing import Iterator
 from typing import Literal
+from typing import Optional
 from typing import Protocol
 from typing import TypeVar
+
+from executing import Executing
 
 from inline_snapshot._change import ChangeBase
 
@@ -11,6 +14,8 @@ T = TypeVar("T", covariant=True)
 
 
 class SnapshotRefBase:
+    _expr: Optional[Executing]
+
     def _changes(self) -> Iterator[ChangeBase]:
         raise NotImplementedError
 

--- a/src/inline_snapshot/testing/_example.py
+++ b/src/inline_snapshot/testing/_example.py
@@ -10,11 +10,14 @@ import sys
 import traceback
 import uuid
 from argparse import ArgumentParser
+from contextlib import ExitStack
 from contextlib import contextmanager
 from io import StringIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Callable
+from typing import ContextManager
+from typing import Sequence
 from unittest.mock import patch
 
 from rich.console import Console
@@ -261,6 +264,7 @@ class Example:
         self,
         args: list[str] = [],
         *,
+        context_managers: Sequence[ContextManager] = (),
         reported_categories: Snapshot[list[Category]] | None = None,
         changed_files: Snapshot[dict[str, str]] | None = None,
         report: Snapshot[str] | None = None,
@@ -274,6 +278,7 @@ class Example:
 
         Parameters:
             args: inline-snapshot arguments (supports only "--inline-snapshot=fix|create|...").
+            context_managers: list of context managers to use when the code is executed.
             reported_categories: snapshot of categories which inline-snapshot thinks could be applied.
             changed_files: snapshot of files which are changed by this run.
             raises: snapshot of the exception raised during test execution.
@@ -311,7 +316,11 @@ class Example:
 
             raised_exception = []
 
-            with deterministic_uuid(), chdir(tmp_path), temp_environ(TERM="unknown"):
+            with ExitStack() as stack:
+                stack.enter_context(deterministic_uuid())
+                stack.enter_context(chdir(tmp_path))
+                stack.enter_context(temp_environ(TERM="unknown"))
+
                 session = SnapshotSession()
 
                 def report_error(message):
@@ -324,6 +333,9 @@ class Example:
                 sys.path.insert(0, str(tmp_path))
 
                 try:
+                    for cm in context_managers:
+                        stack.enter_context(cm)
+
                     enter_snapshot_context()
                     session.load_config(
                         tmp_path / "pyproject.toml",
@@ -394,11 +406,15 @@ class Example:
                     if not tests_found:
                         raise UsageError("no test_*() functions in the example")
 
-                    session.show_report(console)
+                    try:
+                        session.show_report(console)
 
-                    for snapshot in state().snapshots.values():
-                        for change in snapshot._changes():
-                            snapshot_flags.add(change.flag)
+                        for snapshot in state().snapshots.values():
+                            for change in snapshot._changes():
+                                snapshot_flags.add(change.flag)
+                    except Exception as e:
+                        traceback.print_exc()
+                        raised_exception.append(e)
 
                 except StopTesting as e:
                     assert stderr == f"ERROR: {e}\n"
@@ -414,9 +430,11 @@ class Example:
                 if raises is None:
                     raise raised_exception[0]
 
-                assert raises == "\n".join(
+                raises_text = "\n".join(
                     f"{type(e).__name__}:\n" + str(e) for e in raised_exception
                 )
+                raises_text = raises_text.replace(str(tmp_path), "<tmp>")
+                assert raises == raises_text
             else:
                 assert raises == None
 

--- a/tests/test_change_collection_error.py
+++ b/tests/test_change_collection_error.py
@@ -1,0 +1,78 @@
+"""Tests for error handling during change collection in show_report()."""
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from inline_snapshot import snapshot
+from inline_snapshot._external._external import External
+from inline_snapshot._external._external_file import ExternalFile
+from inline_snapshot._inline_snapshot import SnapshotReference
+from inline_snapshot.testing import Example
+from tests.utils import path_transform
+
+
+@pytest.mark.skipif(
+    sys.platform != "linux",
+    reason="test only on linux to prevent problems with path separators",
+)
+@pytest.mark.parametrize(
+    "snapshot_type,expr",
+    [
+        (SnapshotReference, "snapshot()"),
+        (External, "external()"),
+        (ExternalFile, "external_file('test.txt')"),
+    ],
+)
+def test_change_collection_error(expr, snapshot_type):
+    """RuntimeError includes file and line from snapshot._expr when _changes() raises."""
+    Example(
+        f"""\
+from inline_snapshot import snapshot,external,external_file
+
+def test_a():
+    assert "hello" == {expr}
+"""
+    ).run_inline(
+        ["--inline-snapshot=report"],
+        context_managers=[
+            patch.object(
+                snapshot_type,
+                "_changes",
+                side_effect=ValueError("simulated internal error"),
+            )
+        ],
+        raises=path_transform(
+            snapshot(
+                {
+                    "SnapshotReference": """\
+RuntimeError:
+
+error during change collection for snapshot (snapshot())
+snapshot.
+file: <tmp>/tests/test_something.py
+line: 4
+""",
+                    "External": """\
+AssertionError:
+
+RuntimeError:
+
+error during change collection for snapshot (external("uuid:"))
+snapshot.
+file: <tmp>/tests/test_something.py
+line: 4
+""",
+                    "ExternalFile": """\
+AssertionError:
+
+RuntimeError:
+
+error during change collection for snapshot (external_file('<tmp>/tests/test.txt'))
+snapshot.
+""",
+                }
+            )[snapshot_type.__name__]
+        ),
+    )

--- a/tests/test_string.py
+++ b/tests/test_string.py
@@ -1,5 +1,6 @@
 import ast
 
+import pytest
 from hypothesis import given
 from hypothesis.strategies import text
 
@@ -44,149 +45,187 @@ c\\
     )
 
 
-def test_string_newline(check_update):
-    assert check_update('s = snapshot("a\\nb")', flags="update") == snapshot(
-        '''\
+def test_string_newline(check_update2):
+    check_update2(
+        '"a\\nb"',
+        snapshot(
+            '''\
 s = snapshot("""\\
 a
 b\\
 """)\
 '''
+        ),
     )
 
-    assert check_update('s = snapshot("a\\"\\"\\"\\nb")', flags="update") == snapshot(
-        """\
+    check_update2(
+        '"a\\"\\"\\"\\nb"',
+        snapshot(
+            """\
 s = snapshot('''\\
 a\"\"\"
 b\\
 ''')\
 """
+        ),
     )
 
-    assert check_update(
-        's = snapshot("a\\"\\"\\"\\n\\\'\\\'\\\'b")', flags="update"
-    ) == snapshot(
+    check_update2(
+        '"a\\"\\"\\"\\n\\\'\\\'\\\'b"',
         '''\
 s = snapshot("""\\
 a\\"\\"\\"
 \'\'\'b\\
 """)\
-'''
+''',
     )
 
-    assert check_update('s = snapshot(b"a\\nb")') == snapshot('s = snapshot(b"a\\nb")')
+    check_update2('b"a\\nb"', snapshot('s = snapshot(b"a\\nb")'), reported_flags="")
 
-    assert check_update('s = snapshot("\\n\\\'")', flags="update") == snapshot(
-        '''\
+    check_update2(
+        '"\\n\\\'"',
+        snapshot(
+            '''\
 s = snapshot("""\\
 
 '\\
 """)\
 '''
+        ),
     )
 
-    assert check_update('s = snapshot("\\n\\"")', flags="update") == snapshot(
-        '''\
+    check_update2(
+        '"\\n\\""',
+        snapshot(
+            '''\
 s = snapshot("""\\
 
 "\\
 """)\
 '''
+        ),
     )
 
-    assert check_update("s = snapshot(\"'''\\n\\\"\")", flags="update") == snapshot(
-        '''\
+    check_update2(
+        "\"'''\\n\\\"\"",
+        snapshot(
+            '''\
 s = snapshot("""\\
 \'\'\'
 \\"\\
 """)\
 '''
+        ),
     )
 
-    assert check_update('s = snapshot("\\n\b")', flags="update") == snapshot(
-        '''\
+    check_update2(
+        '"\\n\b"',
+        snapshot(
+            '''\
 s = snapshot("""\\
 
 \\x08\\
 """)\
 '''
+        ),
     )
 
 
-def test_string_quote_choice(check_update):
-    assert check_update(
-        "s = snapshot(\" \\'\\'\\' \\'\\'\\' \\\"\\\"\\\"\\nother_line\")",
-        flags="update",
-    ) == snapshot(
-        '''\
+@pytest.fixture()
+def check_update2(check_update):
+    def check(string, expected_str, reported_flags="update"):
+
+        result = check_update(
+            f"s = snapshot({string})\nassert {string} == s",
+            reported_flags=reported_flags,
+            flags="update",
+        )
+        assert result.split("assert")[0].strip() == expected_str
+
+    return check
+
+
+def test_string_quote_choice(check_update2):
+    check_update2(
+        "\" \\'\\'\\' \\'\\'\\' \\\"\\\"\\\"\\nother_line\"",
+        snapshot(
+            '''\
 s = snapshot("""\\
  \'\'\' \'\'\' \\"\\"\\"
 other_line\\
 """)\
 '''
+        ),
     )
 
-    assert check_update(
-        's = snapshot(" \\\'\\\'\\\' \\"\\"\\" \\"\\"\\"\\nother_line")', flags="update"
-    ) == snapshot(
-        """\
+    check_update2(
+        '" \\\'\\\'\\\' \\"\\"\\" \\"\\"\\"\\nother_line"',
+        snapshot(
+            """\
 s = snapshot('''\\
  \\'\\'\\' \"\"\" \"\"\"
 other_line\\
 ''')\
 """
+        ),
     )
 
-    assert check_update('s = snapshot("\\n\\"")', flags="update") == snapshot(
-        '''\
+    check_update2(
+        '"\\n\\""',
+        snapshot(
+            '''\
 s = snapshot("""\\
 
 "\\
 """)\
 '''
+        ),
     )
 
-    assert check_update(
-        "s=snapshot('\\n')", flags="update", reported_flags=""
-    ) == snapshot("s=snapshot('\\n')")
-    assert check_update(
-        "s=snapshot('abc\\n')", flags="update", reported_flags=""
-    ) == snapshot("s=snapshot('abc\\n')")
-    assert check_update("s=snapshot('abc\\nabc')", flags="update") == snapshot(
-        '''\
-s=snapshot("""\\
+    check_update2("'\\n'", snapshot("s = snapshot('\\n')"), reported_flags="")
+    check_update2("'abc\\n'", snapshot("s = snapshot('abc\\n')"), reported_flags="")
+
+    check_update2(
+        "'abc\\nabc'",
+        snapshot(
+            '''\
+s = snapshot("""\\
 abc
 abc\\
 """)\
 '''
+        ),
     )
-    assert check_update("s=snapshot('\\nabc')", flags="update") == snapshot(
-        '''\
-s=snapshot("""\\
+
+    check_update2(
+        "'\\nabc'",
+        snapshot(
+            '''\
+s = snapshot("""\\
 
 abc\\
 """)\
 '''
+        ),
     )
-    assert check_update("s=snapshot('a\\na\\n')", flags="update") == snapshot(
-        '''\
-s=snapshot("""\\
+
+    check_update2(
+        "'a\\na\\n'",
+        snapshot(
+            '''\
+s = snapshot("""\\
 a
 a
 """)\
 '''
+        ),
     )
 
-    assert (
-        check_update(
-            '''\
-s=snapshot("""\\
+    check_update2(
+        '''"""\\
 a
-""")\
-''',
-            flags="update",
-        )
-        == snapshot('s=snapshot("a\\n")')
+"""''',
+        snapshot('s = snapshot("a\\n")'),
     )
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,7 @@
 import contextlib
 
 from inline_snapshot._rewrite_code import ChangeRecorder
+from inline_snapshot.extra import transformation
 
 
 @contextlib.contextmanager
@@ -9,3 +10,8 @@ def apply_changes():
     yield recorder
 
     recorder.fix_all()
+
+
+@transformation
+def path_transform(text):
+    return text.replace("\\", "/")


### PR DESCRIPTION

## Description
<!--
Please provide a clear and concise description of what this pull request does.
Create an issue first if you want to make bigger changes.
-->

## Related Issue(s)
<!--
- Closes #123 (replace with relevant issue number(s), if applicable)
- Related to #456
-->

## Checklist
- [x] I have tested my changes thoroughly (you can download the test coverage with `hatch run cov:github`).
- [ ] I have added/updated relevant documentation.
- [x] I have added tests for new functionality (if applicable).
- [x] I have reviewed my own code for errors.
- [x] I have added a changelog entry with `hatch run changelog:entry`
- [x] I used semantic commits (`feat:` will cause a major and `fix:` a minor version bump)
- [ ] You can squash you commits, otherwise they will be squashed during merge
