### PR TITLE
fix: Fixed a bug where tuples used as snapshot keys caused problems because they had the same hash value #358

### DIFF
--- a/changelog.d/20260313_190540_15r10nk-git.md
+++ b/changelog.d/20260313_190540_15r10nk-git.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed a bug where tuples used as snapshot keys caused problems because they had the same hash value ([#358](https://github.com/15r10nk/inline-snapshot/issues/358))

--- a/src/inline_snapshot/_customize/_custom_sequence.py
+++ b/src/inline_snapshot/_customize/_custom_sequence.py
@@ -17,7 +17,7 @@ class CustomSequenceTypes:
     value_type: type
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, eq=False)
 class CustomSequence(Custom, CustomSequenceTypes):
     value: list[Custom] = field(compare=False)
 

--- a/tests/adapter/test_dict.py
+++ b/tests/adapter/test_dict.py
@@ -35,7 +35,7 @@ def test_dict_constructor():
 from inline_snapshot import snapshot
 
 def test_dict():
-    snapshot(dict())
+    assert {} == snapshot(dict())
 """
     ).run_inline(
         ["--inline-snapshot=fix"],

--- a/tests/test_inline_snapshot.py
+++ b/tests/test_inline_snapshot.py
@@ -694,6 +694,33 @@ assert s["keyb"]==5
     )
 
 
+def test_sub_snapshot_tuple_key():
+    # see https://github.com/15r10nk/inline-snapshot/issues/358
+
+    Example(
+        """\
+from inline_snapshot import snapshot
+
+def test_a():
+    for i in (1,2):
+        assert 5 == snapshot()[(i,)]
+"""
+    ).run_inline(
+        ["--inline-snapshot=create"],
+        changed_files=snapshot(
+            {
+                "tests/test_something.py": """\
+from inline_snapshot import snapshot
+
+def test_a():
+    for i in (1,2):
+        assert 5 == snapshot({(1,): 5, (2,): 5})[(i,)]
+"""
+            }
+        ),
+    )
+
+
 def test_sub_snapshot_empty_string():
 
     Example(


### PR DESCRIPTION

## Description
<!--
Please provide a clear and concise description of what this pull request does.
Create an issue first if you want to make bigger changes.
-->

## Related Issue(s)
<!--
- Closes #123 (replace with relevant issue number(s), if applicable)
- Related to #456
-->

## Checklist
- [ ] I have tested my changes thoroughly (you can download the test coverage with `hatch run cov:github`).
- [ ] I have added/updated relevant documentation.
- [ ] I have added tests for new functionality (if applicable).
- [ ] I have reviewed my own code for errors.
- [ ] I have added a changelog entry with `hatch run changelog:entry`
- [ ] I used semantic commits (`feat:` will cause a major and `fix:` a minor version bump)
- [ ] You can squash you commits, otherwise they will be squashed during merge
