### PR TITLE
fix: dataclasses as dictionary keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', pypy3.9, pypy3.10]
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', pypy3.11]
         os: [ubuntu-latest, windows-2022, macos-14]
         extra_deps: ['"--with=pydantic<2"', '"--with=pydantic>2"']
         is_insider:
@@ -47,9 +47,7 @@ jobs:
         - os: macos-14
           python-version: '3.13'
         - os: macos-14
-          python-version: pypy3.9
-        - os: macos-14
-          python-version: pypy3.10
+          python-version: pypy3.11
 
         - os: windows-2022
           python-version: '3.10'
@@ -60,9 +58,7 @@ jobs:
         - os: windows-2022
           python-version: '3.13'
         - os: windows-2022
-          python-version: pypy3.9
-        - os: windows-2022
-          python-version: pypy3.10
+          python-version: pypy3.11
 
     env:
       TOP: ${{github.workspace}}

--- a/changelog.d/20260423_172841_15r10nk-git.md
+++ b/changelog.d/20260423_172841_15r10nk-git.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Fixed snapshot comparison for dicts where keys are dataclass instances (or other custom objects used as dict keys), which previously caused corrupted snapshots — either collapsing multiple entries into one or appending duplicate keys on subsequent runs ([#363](https://github.com/15r10nk/inline-snapshot/issues/363)).
+- Fixed tuple snapshot updates to compare elements positionally rather than using sequence alignment, so existing expressions (e.g. `3 + 3`) are preserved when elements are removed from or added to a tuple.

--- a/src/inline_snapshot/_customize/_builder.py
+++ b/src/inline_snapshot/_customize/_builder.py
@@ -161,6 +161,8 @@ customized_representation={result!r}
             self._get_handler_recursive(k): self._get_handler_recursive(v)
             for k, v in value.items()
         }
+        assert len(value) == len(custom)
+
         return CustomDict(value=custom)
 
     @property

--- a/src/inline_snapshot/_customize/_custom_call.py
+++ b/src/inline_snapshot/_customize/_custom_call.py
@@ -11,7 +11,7 @@ from inline_snapshot._change import ChangeBase
 from ._custom import Custom
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, eq=False)
 class CustomDefault(Custom):
     value: Custom = field(compare=False)
 
@@ -30,7 +30,7 @@ def unwrap_default(value):
     return value
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, eq=False)
 class CustomCall(Custom):
     node_type = ast.Call
     function: Custom = field(compare=False)

--- a/src/inline_snapshot/_customize/_custom_dict.py
+++ b/src/inline_snapshot/_customize/_custom_dict.py
@@ -11,7 +11,7 @@ from inline_snapshot._change import ChangeBase
 from ._custom import Custom
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, eq=False)
 class CustomDict(Custom):
     node_type = ast.Dict
     value: dict[Custom, Custom] = field(compare=False)

--- a/src/inline_snapshot/_customize/_custom_external.py
+++ b/src/inline_snapshot/_customize/_custom_external.py
@@ -15,7 +15,7 @@ from inline_snapshot._external._format._protocol import get_format_handler
 from ._custom import Custom
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, eq=False)
 class CustomExternal(Custom):
     value: Any
     format: str | None = None

--- a/src/inline_snapshot/_customize/_custom_unmanaged.py
+++ b/src/inline_snapshot/_customize/_custom_unmanaged.py
@@ -10,7 +10,7 @@ from inline_snapshot._change import ChangeBase
 from ._custom import Custom
 
 
-@dataclass()
+@dataclass(eq=False)
 class CustomUnmanaged(Custom):
     value: Any
 

--- a/src/inline_snapshot/_new_adapter.py
+++ b/src/inline_snapshot/_new_adapter.py
@@ -228,9 +228,9 @@ class NewAdapter:
 
         return new_value
 
-    def compare_CustomSequence(
-        self, old_value: CustomSequence, old_node: ast.AST, new_value: CustomSequence
-    ) -> Generator[ChangeBase, None, CustomSequence]:
+    def compare_CustomList(
+        self, old_value: CustomList, old_node: ast.AST, new_value: CustomList
+    ) -> Generator[ChangeBase, None, CustomList]:
 
         if old_node is not None:
             assert isinstance(
@@ -288,8 +288,47 @@ class NewAdapter:
 
         return type(new_value)(result)
 
-    compare_CustomTuple = compare_CustomSequence
-    compare_CustomList = compare_CustomSequence
+    def compare_CustomTuple(
+        self, old_value: CustomTuple, old_node: ast.AST, new_value: CustomTuple
+    ) -> Generator[ChangeBase, None, CustomTuple]:
+        """Compare tuples positionally: match elements at the same index,
+        delete surplus old elements, insert extra new elements."""
+
+        if old_node is not None:
+            assert isinstance(old_node, ast.Tuple)
+
+        old_elts = old_value.value
+        new_elts = new_value.value
+        old_nodes = old_node.elts if old_node is not None else [None] * len(old_elts)
+
+        common = min(len(old_elts), len(new_elts))
+        result = []
+
+        # compare paired elements
+        for old_elem, old_node_elem, new_elem in zip(old_elts, old_nodes, new_elts):
+            v = yield from self.compare(old_elem, old_node_elem, new_elem)
+            result.append(v)
+
+        # delete surplus old elements
+        for old_elem, old_node_elem in zip(old_elts[common:], old_nodes[common:]):
+            yield Delete("fix", self.context.file, old_node_elem, old_elem)
+
+        # insert extra new elements
+        if len(new_elts) > common:
+            to_insert = []
+            for new_elem in new_elts[common:]:
+                new_code = yield from new_elem._code_repr(self.context)
+                to_insert.append((new_code, new_elem))
+                result.append(new_elem)
+            yield ListInsert(
+                "fix",
+                self.context.file,
+                old_node,
+                common,
+                *zip(*to_insert),  # type:ignore
+            )
+
+        return CustomTuple(result)
 
     def compare_CustomDict(
         self, old_value: CustomDict, old_node: ast.Dict, new_value: CustomDict

--- a/tests/adapter/test_dataclass.py
+++ b/tests/adapter/test_dataclass.py
@@ -778,6 +778,46 @@ def test_A():
     )
 
 
+def test_dataclass_as_dict_key_create():
+    """Regression test for CustomCall-keyed dicts: when a dataclass instance is
+    used as a dict key, the snapshot should be created correctly and should not
+    corrupt values on subsequent runs (issue #363 / duplicate report)."""
+    Example(
+        """\
+from dataclasses import dataclass
+from inline_snapshot import snapshot
+
+@dataclass(frozen=True)
+class Container:
+    value: int
+
+def test_something():
+    data = {Container(40): 40, Container(2): 2}
+    assert data == snapshot()
+"""
+    ).run_inline(
+        ["--inline-snapshot=create"],
+        changed_files=snapshot(
+            {
+                "tests/test_something.py": """\
+from dataclasses import dataclass
+from inline_snapshot import snapshot
+
+@dataclass(frozen=True)
+class Container:
+    value: int
+
+def test_something():
+    data = {Container(40): 40, Container(2): 2}
+    assert data == snapshot({Container(value=40): 40, Container(value=2): 2})
+"""
+            }
+        ),
+    ).run_inline(
+        ["--inline-snapshot=fix"], changed_files=snapshot({})
+    )
+
+
 @pytest.mark.skipif(
     sys.version_info < (3, 10),
     reason="NewType is a function in 3.9 and cannot be checked with isinstance or serialized to code",

--- a/tests/adapter/test_sequence.py
+++ b/tests/adapter/test_sequence.py
@@ -119,3 +119,77 @@ def test_tuple():
         ["--inline-snapshot=fix"],
         changed_files=snapshot({}),
     )
+
+
+def test_tuple_fix_shorter():
+    """Tuple shrinks: surplus old elements are deleted, paired elements fixed.
+    Expressions in paired positions are preserved."""
+    Example(
+        """\
+from inline_snapshot import snapshot
+
+def test_tuple():
+    assert (1, 5) == snapshot((0+1, 2, 3, 4, 5))
+"""
+    ).run_inline(
+        ["--inline-snapshot=fix"],
+        changed_files=snapshot(
+            {
+                "tests/test_something.py": """\
+from inline_snapshot import snapshot
+
+def test_tuple():
+    assert (1, 5) == snapshot((0+1, 5))
+"""
+            }
+        ),
+    )
+
+
+def test_tuple_fix_longer():
+    """Tuple grows: paired elements are fixed, extra new elements are inserted."""
+    Example(
+        """\
+from inline_snapshot import snapshot
+
+def test_tuple():
+    assert (1, 2, 3, 4, 5, 6) == snapshot((0+1, 3))
+"""
+    ).run_inline(
+        ["--inline-snapshot=fix"],
+        changed_files=snapshot(
+            {
+                "tests/test_something.py": """\
+from inline_snapshot import snapshot
+
+def test_tuple():
+    assert (1, 2, 3, 4, 5, 6) == snapshot((0+1, 2, 3, 4, 5, 6))
+"""
+            }
+        ),
+    )
+
+
+def test_tuple_update_preserves_expression():
+    """Tuple update: elements whose values haven't changed keep their original
+    expression (e.g. ``2+2`` is not rewritten to ``4``)."""
+    Example(
+        """\
+from inline_snapshot import snapshot
+
+def test_tuple():
+    assert (4, 99) == snapshot((2+2, 1+1))
+"""
+    ).run_inline(
+        ["--inline-snapshot=fix"],
+        changed_files=snapshot(
+            {
+                "tests/test_something.py": """\
+from inline_snapshot import snapshot
+
+def test_tuple():
+    assert (4, 99) == snapshot((2+2, 99))
+"""
+            }
+        ),
+    )

--- a/tests/test_preserve_values.py
+++ b/tests/test_preserve_values.py
@@ -33,7 +33,7 @@ def test_fix_tuple_delete(check_update):
         """assert (1,5)==snapshot((0+1,2,3,4,5))""",
         reported_flags="update,fix",
         flags="fix",
-    ) == snapshot("assert (1,5)==snapshot((0+1, 5))")
+    ) == snapshot("assert (1,5)==snapshot((0+1,5))")
 
 
 def test_fix_dict_change(check_update):
@@ -190,7 +190,7 @@ stuff = [
 ]
 
 
-@pytest.mark.parametrize("braces", ["[]", "()", "{}"])
+@pytest.mark.parametrize("braces", ["[]", "{}"])
 @pytest.mark.parametrize("value_specs", itertools.product(stuff, repeat=3))
 def test_generic(source, braces, value_specs):
     flags = set().union(*[e[3] for e in value_specs])
@@ -213,11 +213,7 @@ def test_generic(source, braces, value_specs):
 
         code = ", ".join(values)
 
-        comma = ""
-        if len(values) == 1 and braces == "()":
-            comma = ","
-
-        return f"{braces[0]}{code}{comma}{braces[1]}"
+        return f"{braces[0]}{code}{braces[1]}"
 
     c1 = build(spec[0] for spec in value_specs)
     c2 = build(spec[1] for spec in value_specs)


### PR DESCRIPTION

## Description
<!--
Please provide a clear and concise description of what this pull request does.
Create an issue first if you want to make bigger changes.
-->

## Related Issue(s)
<!--
- Closes #123 (replace with relevant issue number(s), if applicable)
- Related to #456
-->
closes #363 

## Checklist
- [ ] I have tested my changes thoroughly (you can download the test coverage with `hatch run cov:github`).
- [ ] I have added/updated relevant documentation.
- [ ] I have added tests for new functionality (if applicable).
- [ ] I have reviewed my own code for errors.
- [ ] I have added a changelog entry with `hatch run changelog:entry`
- [ ] I used semantic commits (`feat:` will cause a major and `fix:` a minor version bump)
- [ ] You can squash you commits, otherwise they will be squashed during merge
