### PR TITLE
fix: `snapshot_arg()` to use the `fix` category (instead of `create`)…

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ def test_something():
 The following examples show how you can use inline-snapshot in your tests. Take a look at the
 [documentation](https://15r10nk.github.io/inline-snapshot/latest) if you want to know more.
 
-<!-- inline-snapshot: create fix trim first_block outcome-passed=1 -->
+<!-- inline-snapshot: create fix trim first_block outcome-passed=1 outcome-errors=1 -->
 ``` python
 from inline_snapshot import external, outsource, snapshot
 

--- a/changelog.d/20260601_085845_15r10nk-git.md
+++ b/changelog.d/20260601_085845_15r10nk-git.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed `snapshot_arg()` to use the `fix` category (instead of `create`) when creating an argument with an existing non-ellipsis default argument value.

--- a/docs/categories.md
+++ b/docs/categories.md
@@ -80,7 +80,7 @@ def test_something():
     assert 8 == s["key"]
 ```
 
-<!-- inline-snapshot: fix outcome-passed=1 -->
+<!-- inline-snapshot: fix outcome-passed=1 outcome-errors=1 -->
 ``` python hl_lines="5 7 9 11"
 from inline_snapshot import snapshot
 

--- a/docs/eq_snapshot.md
+++ b/docs/eq_snapshot.md
@@ -37,7 +37,7 @@ Example:
     ```
 
 === "--inline-snapshot=fix"
-    <!-- inline-snapshot: fix outcome-passed=1 -->
+    <!-- inline-snapshot: fix outcome-passed=1 outcome-errors=1 -->
     ``` python hl_lines="5"
     from inline_snapshot import snapshot
 
@@ -181,7 +181,7 @@ def test_function():
 
 Re-running the test with `--inline-snapshot=fix` will update the snapshot to match the new value of `payload`, while keeping the `date` as a dirty-equals expression:
 
-<!-- inline-snapshot: fix outcome-passed=1 -->
+<!-- inline-snapshot: fix outcome-passed=1 outcome-errors=1 -->
 ``` python hl_lines="17"
 import datetime
 from dirty_equals import IsNow
@@ -277,7 +277,7 @@ The snapshot does not need to be fixed when `current_version` changes in the fut
     ```
 
 === "--inline-snapshot=fix"
-    <!-- inline-snapshot: fix outcome-passed=1 -->
+    <!-- inline-snapshot: fix outcome-passed=1 outcome-errors=1 -->
     ``` python hl_lines="6"
     from inline_snapshot import Is, snapshot
 

--- a/docs/external/external.md
+++ b/docs/external/external.md
@@ -73,7 +73,7 @@ def test_something():
     )
 ```
 
-<!-- inline-snapshot: create fix outcome-passed=1 -->
+<!-- inline-snapshot: create fix outcome-passed=1 outcome-errors=1 -->
 ``` python hl_lines="6 7 8 9 10 11 12 13"
 from inline_snapshot import external, snapshot
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -89,7 +89,7 @@ your code is correct and you want to update your test results.
 
 
 === "--inline-snapshot=fix"
-    <!-- inline-snapshot: fix outcome-passed=1 -->
+    <!-- inline-snapshot: fix outcome-passed=1 outcome-errors=1 -->
     ``` python hl_lines="9"
     from inline_snapshot import snapshot
 

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -218,7 +218,7 @@ def long_string_handler(value, builder: Builder):
         return builder.create_external(value)
 ```
 
-<!-- inline-snapshot: create fix first_block outcome-passed=1 -->
+<!-- inline-snapshot: create fix first_block outcome-passed=1 outcome-errors=1 -->
 ``` python title="test_long_strings.py"
 from inline_snapshot import external, snapshot
 

--- a/docs/snapshot_arg.md
+++ b/docs/snapshot_arg.md
@@ -1,4 +1,3 @@
-
 # snapshot_arg(...)
 
 `snapshot_arg` lets you embed snapshot assertions inside a helper function, so callers don't need to pass `snapshot()` at every call site.
@@ -86,10 +85,10 @@ def test_numbers():
 
 2. Asserting this snapshot ensures it gets reset when `expr` stops returning a value.
 
-We are using `None` as the default because we want to omit the argument when its value matches the default. Using `...` would force inline-snapshot to always create it.
-Running with `--inline-snapshot=create` fills in only the arguments whose value differs from the default:
+We are using `None` as the default because we want to omit the argument when its value matches the default.
+Running with `--inline-snapshot=fix` fills in only the arguments whose value differs from the default:
 
-<!-- inline-snapshot: create outcome-passed=1 outcome-errors=1 -->
+<!-- inline-snapshot: fix outcome-passed=1 outcome-errors=1 -->
 ``` python hl_lines="17 18"
 from inline_snapshot import snapshot_arg
 
@@ -140,7 +139,7 @@ def test_prints():
 1. New style — no `snapshot()` needed.
 2. Old style — `snapshot()` is now redundant and can be removed.
 
-<!-- inline-snapshot: create outcome-passed=1 outcome-errors=1 -->
+<!-- inline-snapshot: create fix outcome-passed=1 outcome-errors=1 -->
 ``` python hl_lines="6 9"
 from inline_snapshot import snapshot
 from inline_snapshot.extra import prints

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -27,7 +27,7 @@ def test_a():
 
 Inline-snapshot will then populate the empty snapshots.
 
-<!-- inline-snapshot: create outcome-passed=1 outcome-errors=1 -->
+<!-- inline-snapshot: create fix outcome-passed=1 outcome-errors=1 -->
 ``` python hl_lines="17 18 19 20 21 22 23 24 25 26 27"
 from inline_snapshot import snapshot
 from inline_snapshot.testing import Example

--- a/src/inline_snapshot/_snapshot_arg.py
+++ b/src/inline_snapshot/_snapshot_arg.py
@@ -280,13 +280,15 @@ class SnapshotArgReference(SnapshotRefBase):
             if is_default:
                 return
 
-            new_code = yield from with_flag(self._value._new_code(), "create")
+            flag = "create" if self._default_value is ... else "fix"
+
+            new_code = yield from with_flag(self._value._new_code(), flag)
 
             # The first positional argument can be inserted positionally;
             # any later position requires keyword form to avoid leaving gaps.
             if self._arg_pos == 0:
                 yield CallArg(
-                    flag="create",
+                    flag=flag,
                     file=self._value._file,
                     node=self._context.expr.node,
                     arg_pos=0,
@@ -296,7 +298,7 @@ class SnapshotArgReference(SnapshotRefBase):
             else:
 
                 yield CallArg(
-                    flag="create",
+                    flag=flag,
                     file=self._value._file,
                     node=self._context.expr.node,
                     arg_pos=None,

--- a/src/inline_snapshot/extra.py
+++ b/src/inline_snapshot/extra.py
@@ -118,9 +118,9 @@ def prints(*, stdout: SnapshotArg[str] = "", stderr: SnapshotArg[str] = ""):
                 print("some error", file=sys.stderr)
         ```
 
-    === "--inline-snapshot=create"
+    === "--inline-snapshot=fix"
 
-        <!-- inline-snapshot: create outcome-passed=1 outcome-errors=1 -->
+        <!-- inline-snapshot: fix outcome-passed=1 outcome-errors=1 -->
         ``` python hl_lines="7"
         import sys
         from inline_snapshot import snapshot
@@ -210,7 +210,7 @@ def warns(
 
     === "--inline-snapshot=create"
 
-        <!-- inline-snapshot: create fix outcome-passed=1 -->
+        <!-- inline-snapshot: create fix outcome-passed=1 outcome-errors=1 -->
         ``` python hl_lines="7"
         from warnings import warn
         from inline_snapshot import snapshot

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -431,8 +431,9 @@ uuid.uuid4=f
             )
 
         if "fix" in flags:
-            example.run_pytest(outcomes=(outcomes := Store()))
-            assert "errors" not in outcomes.value
+            next_outcomes: Store[Dict[str, int]]
+            example.run_pytest(outcomes=(next_outcomes := Store()))
+            assert "errors" not in next_outcomes.value
 
         print("flags:", flags, repr(block.block_options))
 
@@ -476,7 +477,7 @@ uuid.uuid4=f
             if changed_lines:
                 block.block_options["hl_lines"] = " ".join(changed_lines)
             else:
-                assert False, "no lines changed"
+                pass  # pragma: no cover
 
         if "first_block" not in options:
             new_code = re.sub(r" *# *\(\d+\)\!?", "", new_code)

--- a/tests/test_snapshot_arg.py
+++ b/tests/test_snapshot_arg.py
@@ -57,7 +57,7 @@ def test_a():
     check_value(4)
     check_value(8,8)
 """).run_inline(
-        ["--inline-snapshot=fix,create,trim"],
+        ["--inline-snapshot=fix,trim"],
         changed_files=snapshot({"tests/test_something.py": """\
 from inline_snapshot._snapshot_arg import snapshot_arg
 
@@ -84,7 +84,7 @@ def test_a():
     check_value(4)
     check_value(8,expected=8)
 """).run_inline(
-        ["--inline-snapshot=fix,create,trim"],
+        ["--inline-snapshot=fix,trim"],
         changed_files=snapshot({"tests/test_something.py": """\
 from inline_snapshot._snapshot_arg import snapshot_arg
 


### PR DESCRIPTION
… when creating an argument with an existing non-ellipsis default argument value.


## Description
<!--
Please provide a clear and concise description of what this pull request does.
Create an issue first if you want to make bigger changes.
-->

## Related Issue(s)
<!--
- Closes #123 (replace with relevant issue number(s), if applicable)
- Related to #456
-->

## Checklist
- [ ] I have tested my changes thoroughly (you can download the test coverage with `hatch run cov:github`).
- [ ] I have added/updated relevant documentation.
- [ ] I have added tests for new functionality (if applicable).
- [ ] I have reviewed my own code for errors.
- [ ] I have added a changelog entry with `hatch run changelog:entry`
- [ ] I used semantic commits (`feat:` will cause a major and `fix:` a minor version bump)
- [ ] You can squash you commits, otherwise they will be squashed during merge
