### PR TITLE
docs: fix typo "note" → "not" in configuration.md default-flags description

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,7 +31,7 @@ fix=["create","fix"]
 * **hash-length:** specifies the length of the hash used by `external()` in the code representation.
     This does not affect the hash length used to store the data.
     The hash should be long enough to avoid hash collisions.
-* **default-flags:** defines which flags should be used if there are no flags specified with `--inline-snapshot=...` and *default-flags-ide* or *default-flags-tui* are note used.
+* **default-flags:** defines which flags should be used if there are no flags specified with `--inline-snapshot=...` and *default-flags-ide* or *default-flags-tui* are not used.
     You can also use the environment variable `INLINE_SNAPSHOT_DEFAULT_FLAGS=...` to specify the flags and to override those in the configuration file.
 
 * **default-flags-tui:** defines which flags should be used if you run pytest in an interactive terminal.


### PR DESCRIPTION
## Description

Fix a typo in the `docs/configuration.md` documentation for the `default-flags` option: "are **note** used" → "are **not** used".

**Before:**
```
defines which flags should be used if there are no flags specified with `--inline-snapshot=...` and *default-flags-ide* or *default-flags-tui* are note used.
```

**After:**
```
defines which flags should be used if there are no flags specified with `--inline-snapshot=...` and *default-flags-ide* or *default-flags-tui* are not used.
```

## Related Issue(s)

None — this is a single-word typo fix in the docs.

## Checklist
- [x] I have tested my changes thoroughly (no code changes; docs only).
- [x] I have added/updated relevant documentation (this IS the doc fix).
- [ ] I have added tests for new functionality (not applicable — docs-only change).
- [x] I have reviewed my own code for errors.
- [ ] I have added a changelog entry with `hatch run changelog:entry` (skipping — single-word typo fix in docs does not warrant a changelog entry).
- [x] I used semantic commits (`docs:` prefix).