### PR TITLE
fix: Pass pytest plugin control variables to test environment

### DIFF
--- a/changelog.d/20260716_044243_mgorny_fix_envvars.md
+++ b/changelog.d/20260716_044243_mgorny_fix_envvars.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- fix passing `PYTEST_DISABLE_PLUGIN_AUTOLOAD` and `PYTEST_PLUGINS` while running the test suite.

--- a/src/inline_snapshot/testing/_example.py
+++ b/src/inline_snapshot/testing/_example.py
@@ -132,6 +132,8 @@ def _subprocess_env() -> dict[str, str]:
         "TOP",
         "COVERAGE_PROCESS_START",
         "PYTHONIOENCODING",
+        "PYTEST_DISABLE_PLUGIN_AUTOLOAD",
+        "PYTEST_PLUGINS",
     ]
     if platform.system() == "Windows":  # pragma: no cover
         env_keys.extend(


### PR DESCRIPTION
## Description
Extend the `_subprocess_env` to include `PYTEST_DISABLE_PLUGIN_AUTOLOAD` and `PYTEST_PLUGINS` variables that are used to control what plugins are used by pytest.  We are using them in Gentoo to ensure that pytest does not autoload one of the 50 other installed plugins, which inevitably change the pytest output and cause the test suite to fail.

## Related Issue(s)
Fixes a regression introduced by #377.

## Checklist
- [x] I have tested my changes thoroughly (you can download the test coverage with `hatch run cov:github`).
- [ ] I have added/updated relevant documentation.
- [ ] I have added tests for new functionality (if applicable).
- [x] I have reviewed my own code for errors.
- [x] I have added a changelog entry with `hatch run changelog:entry`
- [x] I used semantic commits (`feat:` will cause a major and `fix:` a minor version bump)
- [x] You can squash you commits, otherwise they will be squashed during merge
