### PR TITLE
fix: handle disabled pytest capture plugin

### DIFF
--- a/changelog.d/20260731_001850_ShiroKSH_no_capture_crash.md
+++ b/changelog.d/20260731_001850_ShiroKSH_no_capture_crash.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed a crash during session finalization when pytest's capture plugin is disabled.

--- a/src/inline_snapshot/pytest_plugin.py
+++ b/src/inline_snapshot/pytest_plugin.py
@@ -184,7 +184,8 @@ class InlineSnapshotPlugin:
         capture = config.pluginmanager.getplugin("capturemanager")
 
         suspend_capture = (
-            capture._global_capturing is not None
+            capture is not None
+            and capture._global_capturing is not None
             and capture._global_capturing.in_ is not None
             and capture._global_capturing.in_._state == "started"
         )

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -14,6 +14,13 @@ def test_help_message(testdir):
     result.stdout.fnmatch_lines(["inline-snapshot:", "*--inline-snapshot*"])
 
 
+def test_no_capture_plugin():
+    Example("""\
+def test_ok():
+    assert True
+""").run_pytest(["-p", "no:capture"])
+
+
 def test_create():
     Example("""\
 from inline_snapshot import snapshot


### PR DESCRIPTION
## Description

Avoid accessing pytest's capture manager when the capture plugin is disabled.

`pytest_sessionfinish()` previously assumed that `capturemanager` was always registered. With `-p no:capture`, the lookup returns `None`, so a successful test run ended with an `AttributeError`. The existing suspend/resume behavior is unchanged when capture is available.

A subprocess regression test covers a complete pytest run without the capture plugin.

## Related Issue(s)

- Closes #388

## Validation

- `uv run --group dev pytest -q tests/test_pytest_plugin.py::test_no_capture_plugin`
- `uv run --group dev pytest -p no:capture -q tests/test_raises.py::test_raises --inline-snapshot=disable`
- Full suite: 1321 passed, 118 skipped
- Mypy: no issues in 132 source files

## Checklist

- [x] I have tested my changes thoroughly.
- [ ] I have added/updated relevant documentation.
- [x] I have added tests for new functionality.
- [x] I have reviewed my own code for errors.
- [x] I have added a changelog entry.
- [x] I used a semantic commit.
- [x] You can squash my commit.
